### PR TITLE
dk - fixed jwt auth setup

### DIFF
--- a/backend/app/auth.py
+++ b/backend/app/auth.py
@@ -15,13 +15,13 @@ load_dotenv()
 # OIDC / Keycloak configuration
 OIDC_ISSUER = (os.getenv("OIDC_ISSUER") or "").rstrip("/")
 OIDC_JWKS_URL = (os.getenv("OIDC_JWKS_URL") or "").strip()
-# CALIBER_OIDC_AUDIENCE should be set in the deployment environment (e.g. "portal").
-# Falls back to the legacy OIDC_AUDIENCE variable for backward compatibility.
+# Optional audience validation. Set CALIBER_OIDC_AUDIENCE or the legacy
+# OIDC_AUDIENCE when the backend should enforce a specific token audience.
 OIDC_AUDIENCE = (
     os.getenv("CALIBER_OIDC_AUDIENCE")
     or os.getenv("OIDC_AUDIENCE")
-    or "portal"
-).strip()
+    or ""
+).strip() or None
 # Optional local-dev bypass for frontend test-mode. Disabled by default and
 # only honored when OIDC validation is not configured for this backend.
 TEST_TOKEN_ALLOWED = os.getenv("TEST_TOKEN_ALLOWED", "false").lower() in ("1", "true", "yes")
@@ -30,6 +30,7 @@ TEST_TOKEN_USER_ID = os.getenv("TEST_TOKEN_USER_ID", "test-user-1")
 _oidc_jwks_client = None
 _current_user_email: ContextVar[Optional[str]] = ContextVar("current_user_email", default=None)
 _current_user_name: ContextVar[Optional[str]] = ContextVar("current_user_name", default=None)
+_current_user_token: ContextVar[Optional[str]] = ContextVar("current_user_token", default=None)
 
 
 def _audience_matches(claims: dict[str, Any], expected: str | None) -> bool:
@@ -174,12 +175,14 @@ async def get_current_user(
     if _is_local_test_token_enabled() and token.strip() == "test-token-1":
         _current_user_email.set(None)
         _current_user_name.set(None)
+        _current_user_token.set(token.strip())
         return TEST_TOKEN_USER_ID
 
     # Verify the token using the common verification function
     user_id, email, full_name = verify_jwt_token(token)
     _current_user_email.set(email)
     _current_user_name.set(full_name)
+    _current_user_token.set(token)
     return user_id
 
 
@@ -209,12 +212,14 @@ async def get_optional_user(
     if _is_local_test_token_enabled() and token.strip() == "test-token-1":
         _current_user_email.set(None)
         _current_user_name.set(None)
+        _current_user_token.set(token.strip())
         return TEST_TOKEN_USER_ID
     
     try:
         user_id, email, full_name = verify_jwt_token(token)
         _current_user_email.set(email)
         _current_user_name.set(full_name)
+        _current_user_token.set(token)
         return user_id
     except Exception:
         return None
@@ -226,3 +231,7 @@ def get_current_user_email() -> Optional[str]:
 
 def get_current_user_name() -> Optional[str]:
     return _current_user_name.get()
+
+
+def get_current_user_token() -> Optional[str]:
+    return _current_user_token.get()

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -39,7 +39,13 @@ from .crud import (create_question, get_question, get_questions, get_questions_c
                   delete_unverified_questions_by_source)
 from .utils import extract_text_from_pdf, send_to_agent_pipeline, extract_questions_from_pdf_bytes
 from .m2_pipeline import extract_questions_with_m2
-from .auth import get_current_user, get_current_user_email, get_current_user_name, get_optional_user
+from .auth import (
+    get_current_user,
+    get_current_user_email,
+    get_current_user_name,
+    get_current_user_token,
+    get_optional_user,
+)
 from .storage_client import build_pdf_storage_path, upload_pdf_to_storage
 from .roster_integration import (
     call_roster,
@@ -833,14 +839,25 @@ def _roster_call_for_user(
 ):
     user_email = get_current_user_email()
     user_name = get_current_user_name()
+    user_token = get_current_user_token()
     return call_roster(
         method,
         path,
         user_id=user_id,
         user_email=user_email,
         user_name=user_name,
+        user_token=user_token,
         params=params,
         json_body=json_body,
+    )
+
+
+def _fetch_research_id_for_current_user(user_id: str) -> Optional[str]:
+    return fetch_research_id(
+        user_id,
+        user_email=get_current_user_email(),
+        user_name=get_current_user_name(),
+        user_token=get_current_user_token(),
     )
 
 
@@ -1989,7 +2006,7 @@ def get_student_assignment_progress(
             answers={},
             current_question_index=0,
             submitted=False,
-            research_id=fetch_research_id(user_id),
+            research_id=_fetch_research_id_for_current_user(user_id),
         )
 
     import json
@@ -2091,7 +2108,7 @@ def save_student_assignment_progress(
         answers=progress_data.answers,
         current_question_index=progress_data.current_question_index,
         submitted=progress_data.submitted,
-        research_id=fetch_research_id(user_id),
+        research_id=_fetch_research_id_for_current_user(user_id),
     )
 
     import json

--- a/backend/app/roster_integration.py
+++ b/backend/app/roster_integration.py
@@ -18,8 +18,15 @@ def roster_management_enabled() -> bool:
     return ROSTER_MANAGEMENT_ENABLED and bool(ROSTER_BASE_URL)
 
 
-def _build_headers(user_id: str, user_email: Optional[str], user_name: Optional[str]) -> dict[str, str]:
+def _build_headers(
+    user_id: str,
+    user_email: Optional[str],
+    user_name: Optional[str],
+    user_token: Optional[str],
+) -> dict[str, str]:
     headers: dict[str, str] = {"Accept": "application/json"}
+    if user_token:
+        headers["Authorization"] = f"Bearer {user_token}"
     if ROSTER_INTERNAL_SECRET:
         headers["X-Internal-Secret"] = ROSTER_INTERNAL_SECRET
         headers["X-Internal-User-Sub"] = user_id
@@ -55,6 +62,7 @@ def call_roster(
     user_id: str,
     user_email: Optional[str] = None,
     user_name: Optional[str] = None,
+    user_token: Optional[str] = None,
     params: Optional[dict[str, Any]] = None,
     json_body: Optional[dict[str, Any]] = None,
 ) -> Any:
@@ -70,10 +78,16 @@ def call_roster(
         )
 
     url = f"{ROSTER_BASE_URL}{path}"
-    headers = _build_headers(user_id=user_id, user_email=user_email, user_name=user_name)
+    headers = _build_headers(
+        user_id=user_id,
+        user_email=user_email,
+        user_name=user_name,
+        user_token=user_token,
+    )
+    method_upper = method.upper()
     try:
         response = requests.request(
-            method=method.upper(),
+            method=method_upper,
             url=url,
             headers=headers,
             params=params,
@@ -85,6 +99,12 @@ def call_roster(
             status_code=status.HTTP_502_BAD_GATEWAY,
             detail=f"Roster service unavailable: {exc}",
         ) from exc
+
+    if response.status_code == status.HTTP_401_UNAUTHORIZED:
+        raise HTTPException(
+            status_code=status.HTTP_502_BAD_GATEWAY,
+            detail="Roster service rejected Caliber internal credentials",
+        )
 
     if response.status_code >= 400:
         raise HTTPException(
@@ -103,7 +123,13 @@ def call_roster(
         ) from exc
 
 
-def fetch_research_id(user_id: str) -> Optional[str]:
+def fetch_research_id(
+    user_id: str,
+    *,
+    user_email: Optional[str] = None,
+    user_name: Optional[str] = None,
+    user_token: Optional[str] = None,
+) -> Optional[str]:
     """Fetch the anonymous research_id for a student from the roster service.
 
     Only returns a research_id if the student has explicitly consented to
@@ -114,7 +140,14 @@ def fetch_research_id(user_id: str) -> Optional[str]:
     if not roster_management_enabled() or not ROSTER_INTERNAL_SECRET:
         return None
     try:
-        result = call_roster("GET", f"/api/users/{user_id}", user_id=user_id)
+        result = call_roster(
+            "GET",
+            f"/api/users/{user_id}",
+            user_id=user_id,
+            user_email=user_email,
+            user_name=user_name,
+            user_token=user_token,
+        )
         if isinstance(result, dict):
             research_consent = result.get("research_consent")
             # Only tag data with a research_id when the student explicitly consented.

--- a/frontend/src/AuthContext.jsx
+++ b/frontend/src/AuthContext.jsx
@@ -17,6 +17,9 @@ const OIDC_SCOPES = (import.meta.env.VITE_OIDC_SCOPES || 'openid profile email')
 const OIDC_STATE_STORAGE_KEY = 'caliber-oidc-state';
 const OIDC_PKCE_VERIFIER_STORAGE_KEY = 'caliber-oidc-pkce-verifier';
 const OIDC_POST_LOGIN_HASH_STORAGE_KEY = 'caliber-oidc-post-login-hash';
+const OIDC_LOGIN_STARTED_AT_STORAGE_KEY = 'caliber-oidc-login-started-at';
+const OIDC_LOGIN_ERROR_STORAGE_KEY = 'caliber-oidc-login-error';
+const OIDC_LOGIN_RETRY_WINDOW_MS = 15 * 1000;
 
 function portalUrl(path) {
   return PORTAL_BASE_URL ? `${PORTAL_BASE_URL}${path}` : path;
@@ -65,10 +68,35 @@ async function pkceChallengeFromVerifier(verifier) {
 function clearOidcRequestState() {
   sessionStorage.removeItem(OIDC_STATE_STORAGE_KEY);
   sessionStorage.removeItem(OIDC_PKCE_VERIFIER_STORAGE_KEY);
+  sessionStorage.removeItem(OIDC_LOGIN_STARTED_AT_STORAGE_KEY);
+}
+
+function clearOidcLoginError() {
+  sessionStorage.removeItem(OIDC_LOGIN_ERROR_STORAGE_KEY);
+}
+
+function markOidcLoginError(message) {
+  sessionStorage.setItem(OIDC_LOGIN_ERROR_STORAGE_KEY, message || 'OIDC sign in failed');
+}
+
+export function getOidcLoginError() {
+  return sessionStorage.getItem(OIDC_LOGIN_ERROR_STORAGE_KEY) || '';
+}
+
+export function clearOidcLoginStateForRetry() {
+  clearOidcTokens();
+  clearOidcRequestState();
+  clearOidcLoginError();
+}
+
+function directLoginRecentlyStarted() {
+  const startedAt = Number(sessionStorage.getItem(OIDC_LOGIN_STARTED_AT_STORAGE_KEY) || 0);
+  return Boolean(startedAt && Date.now() - startedAt < OIDC_LOGIN_RETRY_WINDOW_MS);
 }
 
 async function startDirectOidcLogin() {
   if (!isDirectOidcEnabled()) return;
+  if (directLoginRecentlyStarted()) return;
 
   const state = randomUrlSafeString(24);
   const verifier = randomUrlSafeString(64);
@@ -76,6 +104,8 @@ async function startDirectOidcLogin() {
 
   sessionStorage.setItem(OIDC_STATE_STORAGE_KEY, state);
   sessionStorage.setItem(OIDC_PKCE_VERIFIER_STORAGE_KEY, verifier);
+  sessionStorage.setItem(OIDC_LOGIN_STARTED_AT_STORAGE_KEY, String(Date.now()));
+  clearOidcLoginError();
 
   const params = new URLSearchParams({
     client_id: OIDC_CLIENT_ID,
@@ -98,7 +128,9 @@ async function handleDirectOidcCallbackIfPresent() {
   if (error) {
     clearOidcTokens();
     clearOidcRequestState();
-    throw new Error(params.get('error_description') || error);
+    const message = params.get('error_description') || error;
+    markOidcLoginError(message);
+    throw new Error(message);
   }
 
   const code = params.get('code');
@@ -110,6 +142,7 @@ async function handleDirectOidcCallbackIfPresent() {
   if (!expectedState || !verifier || state !== expectedState) {
     clearOidcTokens();
     clearOidcRequestState();
+    markOidcLoginError('Invalid OIDC callback state');
     throw new Error('Invalid OIDC callback state');
   }
 
@@ -130,9 +163,12 @@ async function handleDirectOidcCallbackIfPresent() {
   });
 
   if (!response.ok) {
+    const text = await response.text();
     clearOidcTokens();
     clearOidcRequestState();
-    throw new Error('OIDC code exchange failed');
+    const message = `OIDC code exchange failed (${response.status})${text ? `: ${text}` : ''}`;
+    markOidcLoginError(message);
+    throw new Error(message);
   }
 
   const tokenData = await response.json();
@@ -142,6 +178,7 @@ async function handleDirectOidcCallbackIfPresent() {
   });
 
   clearOidcRequestState();
+  clearOidcLoginError();
 
   const cleanedUrl = new URL(window.location.href);
   ['code', 'state', 'session_state', 'iss', 'error', 'error_description'].forEach((key) => {
@@ -199,23 +236,19 @@ async function fetchKeycloakUser() {
       credentials: 'include',
     });
   } else {
-    // Prefer cookie/session auth first so switching portal accounts takes effect immediately.
-    response = await fetch(`${API_BASE}/api/user`, {
-      method: 'GET',
-      headers: {},
-      credentials: 'include',
-    });
-
-    // Fallback to direct OIDC bearer only when cookie auth is unavailable.
-    if (response.status === 401) {
-      const accessToken = await getValidAccessToken();
-      if (accessToken) {
-        response = await fetch(`${API_BASE}/api/user`, {
-          method: 'GET',
-          headers: { Authorization: `Bearer ${accessToken}` },
-          credentials: 'include',
-        });
-      }
+    const accessToken = await getValidAccessToken();
+    if (accessToken) {
+      response = await fetch(`${API_BASE}/api/user`, {
+        method: 'GET',
+        headers: { Authorization: `Bearer ${accessToken}` },
+        credentials: 'include',
+      });
+    } else {
+      response = await fetch(`${API_BASE}/api/user`, {
+        method: 'GET',
+        headers: {},
+        credentials: 'include',
+      });
     }
   }
 

--- a/frontend/src/api.js
+++ b/frontend/src/api.js
@@ -47,6 +47,14 @@ async function getAuthHeaders() {
       'Authorization': 'Bearer test-token-1',
     };
   }
+
+  const accessToken = await getValidAccessToken();
+  if (accessToken) {
+    return {
+      'Authorization': `Bearer ${accessToken}`,
+    };
+  }
+
   // Prefer same-origin cookie/session auth by default.
   return {};
 }

--- a/frontend/src/pages/Auth.jsx
+++ b/frontend/src/pages/Auth.jsx
@@ -1,15 +1,52 @@
 import React from 'react';
-import { useAuth } from '../AuthContext';
+import { clearOidcLoginStateForRetry, getOidcLoginError, useAuth } from '../AuthContext';
 
 export default function Auth() {
   const { signIn } = useAuth();
   const kickedOffRef = React.useRef(false);
+  const [oidcError, setOidcError] = React.useState(() => getOidcLoginError());
 
   React.useEffect(() => {
+    if (oidcError) return;
     if (kickedOffRef.current) return;
     kickedOffRef.current = true;
     signIn();
-  }, [signIn]);
+  }, [oidcError, signIn]);
+
+  const retrySignIn = () => {
+    clearOidcLoginStateForRetry();
+    setOidcError('');
+    kickedOffRef.current = false;
+  };
+
+  if (oidcError) {
+    return (
+      <div style={{ padding: '2rem', textAlign: 'center', color: '#4b5563' }}>
+        <h2 style={{ color: '#111827', marginBottom: '0.75rem' }}>Sign in could not be completed</h2>
+        <p style={{ margin: '0 auto 1rem', maxWidth: 620 }}>
+          Caliber received an OIDC callback error and paused automatic retries.
+        </p>
+        <p style={{ margin: '0 auto 1.5rem', maxWidth: 620, fontSize: '0.9rem' }}>
+          {oidcError}
+        </p>
+        <button
+          type="button"
+          onClick={retrySignIn}
+          style={{
+            border: 0,
+            borderRadius: 6,
+            background: '#2563eb',
+            color: 'white',
+            cursor: 'pointer',
+            fontWeight: 700,
+            padding: '0.75rem 1rem',
+          }}
+        >
+          Try sign in again
+        </button>
+      </div>
+    );
+  }
 
   return (
     <div style={{ padding: '2rem', textAlign: 'center', color: '#4b5563' }}>


### PR DESCRIPTION
This pull request implements improved OIDC (OpenID Connect) error handling and token propagation throughout both the backend and frontend. The main goals are to ensure that OIDC authentication errors are properly surfaced to users with an option to retry, and that user tokens are consistently forwarded to the roster service for authorization. The changes also clean up and clarify audience validation logic and improve the reliability of user identity propagation for research consent.

**OIDC Authentication and Error Handling Improvements:**

* The frontend now captures OIDC callback errors, displays a user-friendly error message on the sign-in page (`Auth.jsx`), and provides a "Try sign in again" button that safely resets OIDC state for retry. [[1]](diffhunk://#diff-e81c41b8586af4b56b1409e2fc29fbff5b0bc7480feac92a878549905411aee1R71-R108) [[2]](diffhunk://#diff-e81c41b8586af4b56b1409e2fc29fbff5b0bc7480feac92a878549905411aee1L101-R133) [[3]](diffhunk://#diff-e81c41b8586af4b56b1409e2fc29fbff5b0bc7480feac92a878549905411aee1R145) [[4]](diffhunk://#diff-e81c41b8586af4b56b1409e2fc29fbff5b0bc7480feac92a878549905411aee1R166-R171) [[5]](diffhunk://#diff-e81c41b8586af4b56b1409e2fc29fbff5b0bc7480feac92a878549905411aee1R181) [[6]](diffhunk://#diff-2a1f8838baae5495133ce47576115a633c0829629bb1c1fc64a5f31600effa9fL2-R49)
* The OIDC login process now tracks recent login attempts to prevent rapid, repeated retries, and stores/retrieves error messages in session storage. [[1]](diffhunk://#diff-e81c41b8586af4b56b1409e2fc29fbff5b0bc7480feac92a878549905411aee1R20-R22) [[2]](diffhunk://#diff-e81c41b8586af4b56b1409e2fc29fbff5b0bc7480feac92a878549905411aee1R71-R108)

**Backend Token Propagation and Roster Integration:**

* The backend now tracks the current user's token in a context variable, making it available for downstream service calls. The roster integration (`call_roster` and `fetch_research_id`) now accepts and forwards the user's token in the `Authorization` header, ensuring proper authentication with the roster service. [[1]](diffhunk://#diff-86fc081feb79aa8cc36bbc781295aec7206367d26ce531ce0628b7b0a989662dR33) [[2]](diffhunk://#diff-86fc081feb79aa8cc36bbc781295aec7206367d26ce531ce0628b7b0a989662dR178-R185) [[3]](diffhunk://#diff-86fc081feb79aa8cc36bbc781295aec7206367d26ce531ce0628b7b0a989662dR215-R222) [[4]](diffhunk://#diff-86fc081feb79aa8cc36bbc781295aec7206367d26ce531ce0628b7b0a989662dR234-R237) [[5]](diffhunk://#diff-82608d38c4441937a3cfb9ff7da1bed9dd59292dec62308de75bfaa2809419a3L42-R48) [[6]](diffhunk://#diff-82608d38c4441937a3cfb9ff7da1bed9dd59292dec62308de75bfaa2809419a3R842-R863) [[7]](diffhunk://#diff-82608d38c4441937a3cfb9ff7da1bed9dd59292dec62308de75bfaa2809419a3L1992-R2009) [[8]](diffhunk://#diff-82608d38c4441937a3cfb9ff7da1bed9dd59292dec62308de75bfaa2809419a3L2094-R2111) [[9]](diffhunk://#diff-5fb151a70884e9d726c31ee1f3ce01a91f44a739cd646040cbb8d13dcaf0c211L21-R29) [[10]](diffhunk://#diff-5fb151a70884e9d726c31ee1f3ce01a91f44a739cd646040cbb8d13dcaf0c211R65) [[11]](diffhunk://#diff-5fb151a70884e9d726c31ee1f3ce01a91f44a739cd646040cbb8d13dcaf0c211L73-R90) [[12]](diffhunk://#diff-5fb151a70884e9d726c31ee1f3ce01a91f44a739cd646040cbb8d13dcaf0c211L106-R132) [[13]](diffhunk://#diff-5fb151a70884e9d726c31ee1f3ce01a91f44a739cd646040cbb8d13dcaf0c211L117-R150)

**OIDC Audience and Environment Variable Handling:**

* The backend OIDC audience validation logic is clarified: audience is now optional and must be explicitly set via `CALIBER_OIDC_AUDIENCE` or `OIDC_AUDIENCE`; there is no default fallback.

**API Authentication Consistency:**

* All frontend API requests now consistently include the user's access token in the `Authorization` header if available, improving backend authentication reliability. [[1]](diffhunk://#diff-a89738858630f071121be18ff14b0d8ef770e718126254d86d2a0f0ce52d8547R50-R57) [[2]](diffhunk://#diff-e81c41b8586af4b56b1409e2fc29fbff5b0bc7480feac92a878549905411aee1L202-L220)

**Roster Service Error Handling:**

* The backend now explicitly handles and surfaces 401 errors from the roster service, returning a 502 to the client if Caliber's internal credentials are rejected.

These changes together improve the robustness, security, and user experience of authentication and authorization flows in the application.