### PR TITLE
dk - added variant generation to frontend

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -33,6 +33,17 @@ LLM_CLEANUP_STYLE_GUIDE_PATH=
 # Enable backend logs for LLM formatter calls and guardrail decisions.
 LLM_CLEANUP_DEBUG=false
 
+# Variant generation LLM.
+# Use gemini for the free Gemini API tier, or openrouter for the original Milestone 2 provider.
+VARIANT_LLM_PROVIDER=gemini
+GEMINI_API_KEY=
+GEMINI_MODEL=gemini-3.1-flash-lite-preview
+# Optional: set false/0 to force text-only generation even if a question has image crops.
+VARIANT_LLM_VISION=true
+# Optional fallback if you switch VARIANT_LLM_PROVIDER=openrouter.
+OPENROUTER_API_KEY=
+OPENROUTER_MODEL=openrouter/free
+
 ROSTER_MANAGEMENT_ENABLED=false
 ROSTER_BASE_URL=http://localhost:8000/roster
 ROSTER_INTERNAL_SECRET=change-me

--- a/backend/app/crud.py
+++ b/backend/app/crud.py
@@ -85,6 +85,17 @@ def get_questions(session: Session, user_id: Optional[str] = None,
     return list(session.exec(statement).all())
 
 
+def get_draft_questions(session: Session, user_id: str, skip: int = 0, limit: int = 100) -> List[Question]:
+    """Get unverified questions for the current user."""
+    return get_questions(
+        session,
+        user_id=user_id,
+        verified_only=False,
+        skip=skip,
+        limit=limit,
+    )
+
+
 def get_questions_count(session: Session, user_id: Optional[str] = None,
                        verified_only: Optional[bool] = None,
                        source_pdf: Optional[str] = None) -> int:
@@ -97,6 +108,11 @@ def get_questions_count(session: Session, user_id: Optional[str] = None,
     if source_pdf:
         statement = statement.where(Question.source_pdf == source_pdf)
     return session.exec(statement).one()
+
+
+def get_draft_questions_count(session: Session, user_id: str) -> int:
+    """Count unverified questions for the current user."""
+    return get_questions_count(session, user_id=user_id, verified_only=False)
 
 
 def get_all_questions(session: Session, skip: int = 0, limit: int = 100) -> List[Question]:

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -3,6 +3,7 @@ import threading
 import uuid
 import time
 import json
+import re
 from pathlib import Path
 from typing import Optional, Dict, Any
 from datetime import datetime, timezone
@@ -31,6 +32,7 @@ from .schemas import (QuestionResponse, UploadResponse, QuestionListResponse, Qu
                      AssignmentGradingResponse, AssignmentGradeUpsertRequest,
                      AssignmentQuestionGradeResponse, RubricPartGradeResponse, RubricLevelCriteria)
 from .crud import (create_question, get_question, get_questions, get_questions_count, get_all_questions,
+                  get_draft_questions, get_draft_questions_count,
                   get_questions_by_ids, update_question, delete_question,
                   get_course_assignments, create_assignment, get_assignment, update_assignment, 
                   delete_assignment, get_assignment_progress, upsert_assignment_progress,
@@ -52,6 +54,7 @@ from .roster_integration import (
     delete_local_course,
     fetch_research_id,
 )
+from .variant_gen import generate_variant, question_to_variant_gen_db
 
 load_dotenv()
 
@@ -448,6 +451,124 @@ def _safe_json_loads(raw: Any, default: Any):
         return json.loads(raw)
     except Exception:
         return default
+
+
+def _variant_question_type(variant_type: str) -> str:
+    vt = (variant_type or "").strip().upper()
+    if vt == "MCQ":
+        return "mcq"
+    if vt == "TRUE_FALSE":
+        return "true_false"
+    return "fr"
+
+
+def _normalize_variant_answer_label(raw_answer: Any) -> str:
+    answer = str(raw_answer or "").strip()
+    if not answer:
+        return ""
+    if answer.upper() in {"TRUE", "T", "YES"}:
+        return "True"
+    if answer.upper() in {"FALSE", "F", "NO"}:
+        return "False"
+    match = re.match(r"^\s*(?:option\s*)?([A-Z1-9])(?:[\.\)]|\s|$)", answer, flags=re.I)
+    return match.group(1).upper() if match else answer
+
+
+def _variant_answer_choices_and_correct_answer(variant: dict[str, Any]) -> tuple[str, str]:
+    qtype = _variant_question_type(str(variant.get("type") or ""))
+    answer = str(variant.get("answer") or "").strip()
+
+    if qtype == "true_false":
+        normalized = _normalize_variant_answer_label(answer)
+        correct = "False" if normalized.upper() == "FALSE" else "True"
+        return json.dumps(["True", "False"]), correct
+
+    if qtype != "mcq":
+        return "[]", answer
+
+    options = variant.get("options")
+    if not isinstance(options, dict) or not options:
+        return "[]", answer
+
+    labels = [str(k).strip() for k in options.keys() if str(k).strip()]
+    choices = [str(options[label]).strip() for label in labels if str(options.get(label) or "").strip()]
+    answer_label = _normalize_variant_answer_label(answer)
+
+    correct = ""
+    for label in labels:
+        if label.upper().rstrip(".):") == answer_label:
+            correct = str(options.get(label) or "").strip()
+            break
+    if not correct and answer in choices:
+        correct = answer
+    if not correct:
+        correct = answer
+
+    return json.dumps(choices), correct
+
+
+def _variant_draft_title(source_question: Question, number: int) -> str:
+    base = (source_question.title or f"Question {source_question.id}").strip()
+    return f"{base} Variant {number}"
+
+
+def _variant_draft_tags(source_question: Question, run_tag: str) -> str:
+    tags = [
+        tag.strip()
+        for tag in (source_question.tags or "").split(",")
+        if tag.strip()
+    ]
+    tags.extend(["variant", "ai-generated", run_tag])
+    seen = set()
+    unique = []
+    for tag in tags:
+        if tag not in seen:
+            unique.append(tag)
+            seen.add(tag)
+    return ",".join(unique)
+
+
+def _save_variant_draft_question(
+    *,
+    session: Session,
+    source_question: Question,
+    variant: dict[str, Any],
+    user_id: str,
+    run_source: str,
+    run_tag: str,
+    number: int,
+) -> Question:
+    answer_choices, correct_answer = _variant_answer_choices_and_correct_answer(variant)
+    question_type = _variant_question_type(str(variant.get("type") or ""))
+    metadata_keywords = [
+        str(variant.get("language") or "").strip(),
+        str(variant.get("algorithm") or "").strip(),
+        str(variant.get("scenario_domain") or "").strip(),
+    ]
+    merged_keywords = ",".join(
+        item for item in [source_question.keywords or "", *metadata_keywords] if item
+    )
+
+    return create_question(
+        session=session,
+        text=str(variant.get("question") or "").strip(),
+        title=_variant_draft_title(source_question, number),
+        tags=_variant_draft_tags(source_question, run_tag),
+        keywords=merged_keywords,
+        school=source_question.school or "",
+        user_school=source_question.user_school or source_question.school or "",
+        course=source_question.course or "",
+        course_type=source_question.course_type or "",
+        question_type=question_type,
+        blooms_taxonomy=source_question.blooms_taxonomy or "",
+        answer_choices=answer_choices,
+        correct_answer=correct_answer,
+        pdf_url=source_question.pdf_url,
+        source_pdf=None,
+        image_url=None,
+        user_id=user_id,
+        is_verified=False,
+    )
 
 
 def _is_auto_graded_question(question: Question) -> bool:
@@ -1291,6 +1412,23 @@ def list_questions(
     )
 
 
+@app.get("/api/questions/drafts", response_model=QuestionListResponse)
+def list_draft_questions(
+    skip: int = 0,
+    limit: int = 100,
+    session: Session = Depends(get_session),
+    user_id: str = Depends(get_current_user)
+):
+    """Get the current user's unverified draft questions."""
+    questions = get_draft_questions(session, user_id=user_id, skip=skip, limit=limit)
+    total = get_draft_questions_count(session, user_id=user_id)
+
+    return QuestionListResponse(
+        questions=questions,
+        total=total
+    )
+
+
 @app.get("/api/questions/all", response_model=QuestionListResponse)
 def list_all_questions(
     skip: int = 0,
@@ -1321,6 +1459,69 @@ def get_question_by_id(
     if not question:
         raise HTTPException(status_code=404, detail="Question not found")
     return question
+
+
+@app.post("/api/questions/{question_id}/variants", response_model=QuestionListResponse, status_code=201)
+def generate_question_variants(
+    question_id: int,
+    count: int = 1,
+    session: Session = Depends(get_session),
+    user_id: str = Depends(get_current_user)
+):
+    """
+    Generate AI variants for a question and save them as unverified draft questions.
+
+    The source question may be any verified question, or an unverified draft owned by
+    the current user. Generated drafts are owned by the current user and tagged with
+    their source question QID; they intentionally do not set ``source_pdf`` because
+    they originate from a question, not a PDF upload.
+    """
+    requested = max(1, min(int(count or 1), 10))
+    source_question = get_question(session, question_id, user_id=None)
+    if not source_question:
+        raise HTTPException(status_code=404, detail="Question not found")
+    if not source_question.is_verified and source_question.user_id != user_id:
+        raise HTTPException(status_code=404, detail="Question not found")
+    if not (source_question.text or "").strip():
+        raise HTTPException(status_code=400, detail="Source question has no text")
+
+    source_db = question_to_variant_gen_db(source_question)
+    generated_variants: list[dict[str, Any]] = []
+    max_outer_attempts = requested * 2
+
+    for _ in range(max_outer_attempts):
+        if len(generated_variants) >= requested:
+            break
+        variant = generate_variant(0, ingestion_index=0, questions_db=source_db)
+        if variant:
+            generated_variants.append(variant)
+
+    if len(generated_variants) < requested:
+        raise HTTPException(
+            status_code=502,
+            detail=(
+                f"Generated {len(generated_variants)} of {requested} requested variants. "
+                "No drafts were saved for this run."
+            ),
+        )
+
+    source_label = source_question.qid or str(source_question.id)
+    run_source = f"variant:{source_label}:{uuid.uuid4().hex[:12]}"
+    run_tag = f"variant-source:{source_label}"
+    drafts = [
+        _save_variant_draft_question(
+            session=session,
+            source_question=source_question,
+            variant=variant,
+            user_id=user_id,
+            run_source=run_source,
+            run_tag=run_tag,
+            number=i,
+        )
+        for i, variant in enumerate(generated_variants, start=1)
+    ]
+
+    return QuestionListResponse(questions=drafts, total=len(drafts))
 
 
 @app.post("/api/questions/batch", response_model=QuestionListResponse)

--- a/backend/app/variant_gen/DESIGN.md
+++ b/backend/app/variant_gen/DESIGN.md
@@ -1,0 +1,129 @@
+# variant_gen — how it works
+
+This file is meant for whoever ships or audits the pipeline later (including a public write-up). Update it when you touch routing, prompts, validation, or the OpenRouter client. It should read like notes from the people who built it, not like marketing copy.
+
+Updated 2026-04-19
+
+---
+
+## What it’s for
+
+Ingested questions—either raw text from **`exam_tests/*.pdf`** or a **`questions.json`-shaped** export—get turned into **variants**: same skill being tested, sometimes with a different skin on the story, always as structured JSON the rest of the app can render.
+
+We’re not building an autograder for arbitrary coursework. The bar is **usable practice material**: good enough to study from, cheap enough to batch overnight, honest about where heuristics lie.
+
+---
+
+## Rough philosophy (why it looks like this)
+
+**Two model calls, not one.** The generator writes `variant_text`, options, and a `correct_answer`. A second pass **re-solves** the problem and checks agreement (MCQ/TF labels) or marks whether the claimed free-response answer is actually right. One-shot “trust my JSON” failed too often—models happily output rubric text as the answer, flip MCQ directions, or agree with themselves on nonsense. A second pass is extra latency and tokens, but it’s the difference between “looks like JSON” and “often right.”
+
+**Rules first, LLM second (mostly).** Stem classification is mostly deterministic: format, language, whether we allow a silly theme, how many MCQ options we enforce. That’s intentional. LLMs are good at paraphrase; they’re mediocre at **consistently** respecting “this PDF says pure C” or “this is a trace, don’t reskin it” across thousands of chunks. We use a small optional router model only for **format + language** when you opt in; mode and reskin stay in code so safety doesn’t depend on router mood.
+
+**Cheap checks before expensive ones.** `generator.py` runs deterministic validation and similarity before it pays for verify. There’s no deep reason beyond cost and annoyance: if the JSON is missing fields or full of placeholder phrases, there’s nothing interesting for the verifier to do.
+
+**One default chat model.** Generate and verify share **`OPENROUTER_MODEL`** unless you override the router slug separately. The old “different model per stage” setup was harder to reproduce and harder to explain in an incident postmortem. You can still split models later if you have evidence one model is systematically better at verify—nothing in the code forbids it.
+
+**Retries bump temperature slightly.** If verify disagrees or the JSON is invalid, we retry a few times with a bit more sampling noise. Not sophisticated; it just unsticks local minima without hand-tuning per exam.
+
+---
+
+## Where questions come from
+
+Same JSON shape either way: top-level `ingestions` list.
+
+Default: `exam_tests_questions` walks `exam_tests/*.pdf`, pdfminer text, heuristic split on headers like “Problem 2”, “3. What…”. We normalize `\r`, then replace form-feed `\f` with newline so `(?m)^` splitters see real line starts. That one’s worth spelling out: pdfminer was giving us page breaks as `\f`, and regexes anchored at line start never fired—so a whole exam page could end up as **one** “question,” and every classifier downstream guessed wrong.
+
+`VARIANT_GEN_QUESTIONS_JSON` or `--db` loads layout output instead. Re-ingesting after splitter changes **changes** `question_id` hashes; `variants.json` dedupes by `original_id`, so stale rows don’t auto-heal.
+
+Tail trim: boilerplate headings like “answer key” / “solutions to…” get cut so solution keys don’t dominate the student prompt.
+
+**Diagrams.** Default PDF ingest sets `image_crops` to `[]`—there is no “figure” in the pipeline unless something else fills that field. If layout JSON attaches crops **and** the stem looks diagram-ish (and isn’t obviously “write this function”), generation can send **one** image to OpenRouter when vision is enabled. Verify stays **text-only** on purpose: we didn’t want to double multimodal cost on every question, and we’re implicitly betting that a good variant **restates** anything essential from the figure in words. That bet is wrong for some exams; it’s a known trade.
+
+---
+
+## Routing (`question_contract`, `question_inputs`, `question_router`)
+
+Everything downstream reads a **`QuestionContract`**: `language`, `mode`, `allow_thematic_reskin`, `question_format` (MCQ / FREE_RESPONSE / TRUE_FALSE), **`expected_mcq_options`** (how strictly we enforce MCQ option count), `routing_source`.
+
+**`route_stem(text)`** is the only entry from `generator.py`. Rules path = `build_question_contract`. Optional **`QUESTION_ROUTER=llm`**: one small JSON call sets `question_format` + `language` only; mode and reskin stay rule-derived so we don’t accidentally enable parking-lot reskins on trace questions. Bad router output → rules fallback (one console line).
+
+**Format (`detect_format`)** order matters: true/false stubs early; “write a function / pseudocode” forces FR before loose MCQ regexes; numbered multi-part worksheets can look like MCQ lines—bail to FR; `(a)`–`(e)` plus “which of the following” catches AP-style lettered answers that `A.` regexes miss.
+
+**Language** tries Java/AP signals before the loose C++ `int x = …;` heuristic so snippets without `import` don’t land as Python. Stanford-style `VectorNew` / `VectorSplit` + no `std::` → **`generic`** so we don’t demand C++-shaped answers for C. **`_mentions_cpp_as_required_language`** exists because “no C++ whatsoever” still contains the substring `c++`. Default fallthrough is still **python** for ambiguous prose (Scheme, etc.): that’s lazy but fixable with `QUESTION_LANG` or the router.
+
+**Mode**: `class_design` vs `conceptual` vs `algorithmic`. Thematic reskin only for algorithmic stems that aren’t structural traces and aren’t “write a function **named** …”—we burned a lot of time on verify failures before we turned that off. When reskin is off we reuse the same CS-only scenario block as conceptual.
+
+**`expected_mcq_options`**: from **`expected_mcq_options_for_stem`** using the same stem + format + language. `count_options` lives in **`question_inputs`**. Not MCQ → 0. MCQ but fewer than two detected lines → assume **4**. Language **cpp** → **0** because numbered code lines masquerade as options. Same number feeds **`is_invalid_variant`** so we don’t compute it twice in different places.
+
+---
+
+## Environment (one place)
+
+| Variable | Role |
+|----------|------|
+| `VARIANT_LLM_PROVIDER` | `gemini` or `openrouter`; Milestone 1 default is `gemini` |
+| `GEMINI_API_KEY` / `GOOGLE_API_KEY` | Required when `VARIANT_LLM_PROVIDER=gemini` |
+| `GEMINI_MODEL` | Gemini generate + verify model, default `gemini-3.1-flash-lite-preview` |
+| `OPENROUTER_API_KEY` | Required when `VARIANT_LLM_PROVIDER=openrouter` |
+| `OPENROUTER_MODEL` | OpenRouter generate + verify slug default |
+| `OPENROUTER_TIMEOUT` | Generate read timeout (s), default 90; shared by Gemini unless overridden per call |
+| `OPENROUTER_TIMEOUT_VERIFY` | Verify read timeout (s), default 55 |
+| `VARIANT_LLM_HTTP_RETRIES` / `OPENROUTER_HTTP_RETRIES` | TLS/connection retries, default 3 |
+| `VARIANT_LLM_VISION` / `OPENROUTER_VISION` / `OPENROUTER_SEND_IMAGES` | Disable with `0`/`false` to force text-only |
+| `GENERATION_SOURCE_MAX_CHARS` | Clip stem for generation prompt |
+| `VERIFY_VARIANT_TEXT_MAX_CHARS` | Clip `variant_text` embedded in verify |
+| `QUESTION_LANG` | Force `python` / `cpp` / `java` / `generic` for a whole run |
+| `QUESTION_ROUTER` | `rules` (default) or `llm` |
+| `QUESTION_ROUTER_MODEL` | Optional slug for router (defaults to `OPENROUTER_MODEL`) |
+| `QUESTION_ROUTER_TIMEOUT` | Router call timeout (s), default 25 |
+| `VARIANT_GEN_TELEMETRY` | `1` / `true` → `[variant_gen:telemetry]` JSON lines |
+| `VARIANT_GEN_QUESTIONS_JSON` | Path to questions JSON when not using `--db` |
+
+---
+
+## Prompts (`prompts.py`)
+
+Generation is one long instruction; verify is separate. MCQ verify lists **actual** option keys from the JSON—hardcoding A–E broke real exams. Verify text is head+tail truncated with a middle omission note when huge; otherwise prompts blow past context limits and you get truncated JSON back.
+
+Extras (`prompt_extras`): nudges for list/dict/set/vector method MCQs; conceptual items must not become coding tasks unless the source asked for code; trace / no-reskin FR stays in CS vocabulary; named-function stems must keep names/types; class_design Python warns that ingest may paste an answer key—keep student text clean, code only in `correct_answer`. The output-only verify hint keys off **variant** text (“what is the output…”). If a reskin drops that wording, the hint doesn’t fire—that’s logged as a gap, not ignored.
+
+---
+
+## Validation (`variant_validation.py`)
+
+Placeholder fragments in model output → reject. Similarity gate uses `SequenceMatcher`; explanation-style originals get a looser threshold so a light rewrite doesn’t get thrown out.
+
+FR **`correct_answer`**: empty or rubric phrases → reject. **Code-shaped** answer required only when **`_variant_asks_for_code_submission`** *and* **`original_asks_for_code_submission`**—we got burned when reskins added “implement a function” and suddenly the validator demanded code for a trace question. Python answers optionally `ast`-checked; mutable default `[]`/`{}` rejected unless the original showed that pattern. Conceptual mode can run **`free_response_cs_vocabulary_lost`** so explain/compare items don’t drift into unrelated domains.
+
+MCQ: need an `options` dict; garbage “all 0.1234” numeric distractors → reject.
+
+---
+
+## Python policy (`policies/python_intro.py`)
+
+Linked-list homework (`reverseList`, “linked list”) is excluded from “list method MCQ” heuristics so we don’t confuse nodes with `list.append`. Autofix can pin `correct_answer` when exactly one real (or fake, for “which is NOT”) list method option exists.
+
+---
+
+## OpenRouter (`llm_client.py`)
+
+JSON mode, fence stripping on parse. Verify timeout is lower than generate so one bad prompt doesn’t hold the whole batch hostage. Retries on flaky TLS/connect noise—that was a practical fix for laptops on bad Wi‑Fi, not a theoretical nicety.
+
+---
+
+## Batch runner
+
+Appends to `exam_tests/variants.json`, skips `question_id` already present, atomic save per question, short sleep between calls, passes preloaded `questions_db` so PDFs aren’t re-read every index.
+
+---
+
+## Tests
+
+From `server/`: `python -m unittest variant_gen.tests.test_stem_routing -v` (rules routing; no API key).
+
+---
+
+## What we’re explicitly not doing (yet)
+
+Perfect PDF understanding without layout help. Guaranteed semantic correctness on every variant. Full multimodal verify. Automatic repair of every kind of OCR garbage. If you need those, you’ll extend this layer—or replace the stem router with something heavier—and this doc should get a paragraph when you do.

--- a/backend/app/variant_gen/__init__.py
+++ b/backend/app/variant_gen/__init__.py
@@ -1,0 +1,44 @@
+"""Variant generation pipeline (LLM generate → validate → verify).
+
+Public API is loaded on first access so ``python -m variant_gen.generator`` does not
+pre-import the generator via the package __init__.
+"""
+
+from typing import Any
+
+__all__ = [
+    "DB_PATH",
+    "EXAM_TESTS_DIR",
+    "generate_variant",
+    "load_questions_database",
+    "question_to_variant_gen_db",
+    "question_to_variant_gen_question",
+]
+
+
+def __getattr__(name: str) -> Any:
+    if name == "DB_PATH":
+        from .config import DB_PATH as _DB_PATH
+
+        return _DB_PATH
+    if name == "EXAM_TESTS_DIR":
+        from .exam_tests_questions import EXAM_TESTS_DIR as _EXAM_TESTS_DIR
+
+        return _EXAM_TESTS_DIR
+    if name == "load_questions_database":
+        from .exam_tests_questions import load_questions_database as _load
+
+        return _load
+    if name == "generate_variant":
+        from .generator import generate_variant as _generate_variant
+
+        return _generate_variant
+    if name == "question_to_variant_gen_db":
+        from .milestone_one_adapter import question_to_variant_gen_db as _adapt_db
+
+        return _adapt_db
+    if name == "question_to_variant_gen_question":
+        from .milestone_one_adapter import question_to_variant_gen_question as _adapt_question
+
+        return _adapt_question
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")

--- a/backend/app/variant_gen/config.py
+++ b/backend/app/variant_gen/config.py
@@ -1,0 +1,127 @@
+"""Environment, paths, and model constants for variant_gen."""
+
+import os
+from pathlib import Path
+
+from dotenv import load_dotenv
+
+from .exam_tests_questions import EXAM_TESTS_DIR
+
+_APP_DIR = Path(__file__).resolve().parent.parent
+_BACKEND_DIR = _APP_DIR.parent
+load_dotenv(_BACKEND_DIR / ".env")
+load_dotenv(_APP_DIR / ".env")
+load_dotenv()
+
+BASE_DIR = _BACKEND_DIR
+DB_PATH = EXAM_TESTS_DIR
+
+OPENROUTER_URL = "https://openrouter.ai/api/v1/chat/completions"
+GEMINI_URL_TEMPLATE = "https://generativelanguage.googleapis.com/v1beta/models/{model}:generateContent"
+
+# Default when OPENROUTER_MODEL is unset (OpenRouter slug).
+DEFAULT_OPENROUTER_MODEL = "openai/gpt-4o-mini"
+DEFAULT_GEMINI_MODEL = "gemini-3.1-flash-lite-preview"
+
+
+def variant_llm_provider() -> str:
+    """Provider used for variant generation calls: openrouter or gemini."""
+    raw = os.getenv("VARIANT_LLM_PROVIDER", os.getenv("LLM_PROVIDER", "openrouter"))
+    name = raw.strip().lower()
+    aliases = {"google": "gemini", "google-gemini": "gemini", "open_router": "openrouter"}
+    return aliases.get(name, name)
+
+
+def resolved_openrouter_model() -> str:
+    return os.getenv("OPENROUTER_MODEL", "").strip() or DEFAULT_OPENROUTER_MODEL
+
+
+def resolved_gemini_model() -> str:
+    return os.getenv("GEMINI_MODEL", "").strip() or DEFAULT_GEMINI_MODEL
+
+
+def resolved_llm_model(provider: str | None = None) -> str:
+    name = provider or variant_llm_provider()
+    if name == "gemini":
+        return resolved_gemini_model()
+    return resolved_openrouter_model()
+
+
+def resolved_question_router_model() -> str:
+    """Model slug/name for ``QUESTION_ROUTER=llm`` (defaults to main generate model)."""
+    return os.getenv("QUESTION_ROUTER_MODEL", "").strip() or resolved_llm_model()
+
+
+def question_router_name() -> str:
+    return os.getenv("QUESTION_ROUTER", "rules").strip().lower()
+
+
+def question_router_timeout_sec() -> float:
+    return float(os.getenv("QUESTION_ROUTER_TIMEOUT", "25"))
+
+
+def telemetry_enabled() -> bool:
+    """Emit one-line JSON routing / outcome events when ``VARIANT_GEN_TELEMETRY=1``."""
+    return os.getenv("VARIANT_GEN_TELEMETRY", "").strip().lower() in ("1", "true", "yes", "on")
+
+
+def variant_vision_enabled() -> bool:
+    """Multimodal requests allowed (crop + text in one call)."""
+    return os.getenv(
+        "VARIANT_LLM_VISION",
+        os.getenv("OPENROUTER_VISION", os.getenv("OPENROUTER_SEND_IMAGES", "1")),
+    ).lower() not in (
+        "0",
+        "false",
+        "no",
+    )
+
+
+def openrouter_vision_enabled() -> bool:
+    """Backward-compatible name used by older variant_gen modules."""
+    return variant_vision_enabled()
+
+
+DEBUG = False
+MAX_RETRIES = 3
+
+# HTTP read timeouts (seconds) for OpenRouter. Verify is usually short; keep it lower so a
+# hung or token-bloated call does not block the batch for minutes.
+def openrouter_timeout_generate() -> float:
+    return float(os.getenv("OPENROUTER_TIMEOUT", "90"))
+
+
+def openrouter_timeout_verify() -> float:
+    return float(os.getenv("OPENROUTER_TIMEOUT_VERIFY", "55"))
+
+
+def verify_variant_text_max_chars() -> int:
+    """Cap variant_text size embedded in verify prompts (avoids huge completions / slow calls)."""
+    return max(4000, int(os.getenv("VERIFY_VARIANT_TEXT_MAX_CHARS", "14000")))
+
+
+def generation_source_max_chars() -> int:
+    """Cap raw question text sent to the generation prompt only."""
+    return max(12000, int(os.getenv("GENERATION_SOURCE_MAX_CHARS", "26000")))
+
+
+BASE_TEMPERATURE = 0.4
+SIMILARITY_THRESHOLD = 0.6
+SIMILARITY_THRESHOLD_EXPLANATION = 0.72
+
+_ALGORITHM_PATTERNS = [
+    ("hash map lookup", ["hash", "dictionary", "dict", "lookup", "two sum", "key", "mapping"]),
+    ("graph traversal", ["graph", "bfs", "dfs", "breadth", "depth", "adjacen", "vertex", "edge", "shortest path", "dijkstra", "spanning tree", "kruskal"]),
+    ("dynamic programming", ["dynamic programming", "memoiz", "tabulation", "subproblem", "overlapping", "optimal substructure", "longest common", "knapsack"]),
+    ("sorting / ordering", ["sort", "order", "rank", "arrange", "ascending", "descending", "merge sort", "quicksort", "bubble"]),
+    ("binary search", ["binary search", "bisect", "sorted array", "log n", "divide and conquer"]),
+    ("recursion", ["recurs", "base case", "recursive"]),
+    ("tree traversal", ["tree", "preorder", "inorder", "postorder", "binary tree", "bst", "traversal"]),
+    ("linked list", ["linked list", "singly linked", "head", "node", "next pointer", "reverse"]),
+    ("stack / queue", ["stack", "queue", "push", "pop", "peek", "fifo", "lifo"]),
+    ("set operations", ["set", "intersection", "union", "difference", "common elements"]),
+    ("string manipulation", ["string", "substring", "reverse", "palindrome", "anagram", "character"]),
+    ("array search", ["array", "list", "find", "search", "index", "element"]),
+    ("greedy", ["greedy", "optimal", "locally optimal"]),
+    ("class design / OOP", ["class", "inherit", "object", "method", "__init__", "__str__", "attribute"]),
+]

--- a/backend/app/variant_gen/eval_batch.py
+++ b/backend/app/variant_gen/eval_batch.py
@@ -1,0 +1,155 @@
+"""
+Small fixed-index generation run for spot-checking (concept, API MCQ, OOP, recursion).
+
+Does not touch layout_debug/variants.json — writes layout_debug/variants_eval.json by default.
+
+From the server directory:
+
+  python -m variant_gen.eval_batch
+  python -m variant_gen.eval_batch --exam-id practicefinal3 --indices 0,1,2
+  python -m variant_gen.eval_batch --indices 1,2,3,10,14
+  python -m variant_gen.eval_batch --ingestion -1 --indices 0,1,2
+
+``--exam-id`` selects the ingestion whose ``exam_id`` matches (last match wins).
+Otherwise ``--ingestion`` is the 0-based index among ingestions (``-1`` = last).
+Default indices assume a ~15+ question set; shorten ``--indices`` for smaller exams.
+
+By default questions are parsed from ``exam_tests/*.pdf``. Optional ``--db`` loads a layout JSON file.
+
+Or use VS Code / Cursor "Run Python File" on this module — the path bootstrap below makes that work.
+"""
+
+import argparse
+import json
+import sys
+import time
+from pathlib import Path
+
+if __name__ == "__main__":
+    _server_dir = Path(__file__).resolve().parent.parent
+    if str(_server_dir) not in sys.path:
+        sys.path.insert(0, str(_server_dir))
+
+from variant_gen import EXAM_TESTS_DIR, generate_variant
+from variant_gen.exam_tests_questions import load_questions_database
+from variant_gen.ingestion_resolve import resolve_ingestion_index
+
+# Default indices span a mid-sized exam; use --indices for shorter ingestions.
+DEFAULT_INDICES = [1, 2, 3, 5, 8, 10, 12, 14]
+DEFAULT_OUT = EXAM_TESTS_DIR / "variants_eval.json"
+
+
+def main():
+    ap = argparse.ArgumentParser(description="Run variant generation on a few indices for eval.")
+    ap.add_argument(
+        "--indices",
+        default=",".join(str(i) for i in DEFAULT_INDICES),
+        help=f"comma-separated 0-based indices (default: {DEFAULT_INDICES})",
+    )
+    ap.add_argument(
+        "--out",
+        type=Path,
+        default=DEFAULT_OUT,
+        help=f"output JSON path (default: {DEFAULT_OUT})",
+    )
+    ap.add_argument(
+        "--db",
+        type=Path,
+        default=None,
+        help="optional questions.json; default is exam_tests PDFs or VARIANT_GEN_QUESTIONS_JSON",
+    )
+    ap.add_argument(
+        "--ingestion",
+        type=int,
+        default=0,
+        help="0-based ingestion index (-1=last; default 0); ignored if --exam-id is set",
+    )
+    ap.add_argument(
+        "--exam-id",
+        default=None,
+        metavar="ID",
+        help="select ingestion by exam_id (exact match; last match wins); overrides --ingestion",
+    )
+    args = ap.parse_args()
+    indices = [int(x.strip()) for x in args.indices.split(",") if x.strip()]
+
+    try:
+        source_data = load_questions_database(args.db)
+    except (OSError, json.JSONDecodeError, ValueError) as e:
+        print(f"Error loading questions: {e}", file=sys.stderr)
+        sys.exit(1)
+    ingestions = source_data["ingestions"]
+    try:
+        ing_idx = resolve_ingestion_index(
+            ingestions,
+            exam_id=args.exam_id,
+            ingestion_index=args.ingestion,
+        )
+    except (ValueError, IndexError) as e:
+        print(f"Error: {e}", file=sys.stderr)
+        sys.exit(1)
+    ing = ingestions[ing_idx]
+    questions = ing["questions"]
+    ing_id = ing.get("ingestion_id", "?")
+    print(
+        f"Using ingestion [{ing_idx}] exam_id={ing.get('exam_id', '?')} {ing_id} ({len(questions)} questions)"
+    )
+
+    rows = []
+    for idx in indices:
+        if idx < 0 or idx >= len(questions):
+            rows.append(
+                {
+                    "ingestion_index": ing_idx,
+                    "ingestion_id": ing_id,
+                    "index": idx,
+                    "error": "index out of range",
+                    "variant": None,
+                }
+            )
+            print(f"\n=== index {idx} OUT OF RANGE (0–{len(questions) - 1}) ===")
+            continue
+        q = questions[idx]
+        qid = q.get("question_id")
+        preview = (q.get("text") or "")[:72].replace("\n", " ")
+        print(f"\n=== index {idx} | {qid} ===")
+        print(f"    {preview}...")
+        t0 = time.time()
+        variant = generate_variant(
+            idx,
+            db_path=args.db,
+            ingestion_index=ing_idx,
+            questions_db=source_data,
+        )
+        elapsed = time.time() - t0
+        if variant:
+            print(f"    ok ({elapsed:.1f}s) [{variant.get('scenario_domain', '?')}]")
+            rows.append(
+                {
+                    "ingestion_index": ing_idx,
+                    "ingestion_id": ing_id,
+                    "index": idx,
+                    "original_id": qid,
+                    "variant": variant,
+                }
+            )
+        else:
+            print(f"    fail ({elapsed:.1f}s)")
+            rows.append(
+                {
+                    "ingestion_index": ing_idx,
+                    "ingestion_id": ing_id,
+                    "index": idx,
+                    "original_id": qid,
+                    "variant": None,
+                }
+            )
+
+    args.out.parent.mkdir(parents=True, exist_ok=True)
+    with open(args.out, "w", encoding="utf-8") as f:
+        json.dump(rows, f, indent=2, ensure_ascii=False)
+    print(f"\nWrote {len(rows)} row(s) to {args.out}")
+
+
+if __name__ == "__main__":
+    main()

--- a/backend/app/variant_gen/exam_tests_questions.py
+++ b/backend/app/variant_gen/exam_tests_questions.py
@@ -1,0 +1,182 @@
+"""
+Build the questions.json-shaped dict used by variant_gen directly from PDFs in
+``<repo>/exam_tests``, without going through the layout pipeline.
+
+Override with env ``VARIANT_GEN_QUESTIONS_JSON=/path/to/file.json`` to load a
+fixed JSON file instead (same schema: top-level ``ingestions`` list).
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import re
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+_SERVER_DIR = Path(__file__).resolve().parent.parent
+REPO_ROOT = _SERVER_DIR.parent
+EXAM_TESTS_DIR = REPO_ROOT / "exam_tests"
+
+# Line starts a new question when it looks like a problem header, not a code line number or "1. union".
+_LIST_METHOD_WORDS = (
+    "union|extend|append|pop|sort|reverse|remove|insert|index|count|copy|"
+    "clear|keys|values|items|get|setdefault"
+)
+_QOPEN = (
+    r"What|Which|Whom|Whose|Suppose|The following|All of the|All of|After|"
+    r"If\s+the|If\s+a|If\s+an|If\s+all|If\s+each|If\s+you|If\s+we|If\s+this|If\s+that|If\s+two|"
+    r"If\s+there|If\s+your|If\s+the\s+input|If\s+the\s+following|How|Name|Explain|"
+    r"Determine|Consider|Using\s+the|Using\s+a|Using\s+an|Write|Complete|Indicate|Fill|Circle|True|False|List|Show|Define|"
+    r"State|Why|Compute|Design|Find|Prove|Provide|Given|Assume|Implement|Each|Every|Mark|Select|"
+    r"Match|Identify|Outline|Describe|Compare|Arrange|Order|Evaluate|Calculate|Simplify|Convert|"
+    r"Trace|Draw|Sketch|Rank|Sort|For each|For every|By selecting|Consider the"
+)
+_PROBLEM_HEADER = re.compile(
+    r"(?mi)^[ \t]*(?:"
+    r"Problem\s+(?:One|Two|Three|Four|Five|Six|Seven|Eight|Nine|Ten|\d{1,3})\s*[:\.]?\s*"
+    r"|Question\s+\d+\s*$"
+    r"|\d{1,3}\)\s+"
+    rf"|\d{{1,3}}\.(?:[ \t]|\n)+(?!(?:{_LIST_METHOD_WORDS})\b)(?=(?:{_QOPEN}|\())"
+    r")",
+)
+
+# Trim trailing solution sections only when the heading is unambiguous (not "Solutions can be found …").
+_BOILERPLATE_TAIL = re.compile(
+    r"(?mis)(?:^|\n)\s*(?:"
+    r"answer\s*key|works\s+cited|"
+    r"solutions?\s+to\s+(?:the\s+)?(?:problems|exercises|questions)|"
+    r"detailed\s+solutions"
+    r")\b.*\Z"
+)
+
+
+def _pdf_relative_path(pdf: Path) -> str:
+    try:
+        return str(pdf.resolve().relative_to(REPO_ROOT.resolve()))
+    except ValueError:
+        return str(pdf)
+
+
+def _stable_question_id(stem: str, index: int, text: str) -> str:
+    h = hashlib.sha1(f"{stem}:{index}:{text[:200]}".encode("utf-8")).hexdigest()[:16]
+    return f"q_exam_{stem}_{index:03d}_{h}"
+
+
+def _extract_pdf_text(path: Path) -> str:
+    try:
+        from pdfminer.high_level import extract_text
+    except ImportError as e:  # pragma: no cover
+        raise ImportError(
+            "pdfminer.six is required to read exam_tests PDFs. "
+            "Install dependencies from the repo requirements.txt."
+        ) from e
+    raw = extract_text(str(path)) or ""
+    # Normalize odd PDF whitespace but keep paragraph breaks
+    raw = raw.replace("\r\n", "\n").replace("\r", "\n")
+    # Page breaks from pdfminer are often \f; they are not newlines for ^ in regex, so
+    # question-start patterns like "3.  Consider" would fail to match and multiple items
+    # get glued into one blob (bad for MCQ verify).
+    raw = raw.replace("\f", "\n")
+    raw = re.sub(r"[ \t]+\n", "\n", raw)
+    raw = re.sub(r"\n{3,}", "\n\n", raw)
+    return raw.strip()
+
+
+def _trim_solutions_block(text: str) -> str:
+    m = _BOILERPLATE_TAIL.search(text)
+    if m:
+        return text[: m.start()].strip()
+    return text
+
+
+def split_pdf_text_into_questions(text: str) -> List[str]:
+    """
+    Heuristic split of full exam text into standalone question strings.
+    Tuned for common CS exam PDFs (Problem N, Question N, 1. / 1) prefixes).
+    """
+    text = _trim_solutions_block(text)
+    if not text:
+        return []
+
+    matches = list(_PROBLEM_HEADER.finditer(text))
+    if not matches:
+        return [text] if len(text) >= 40 else []
+
+    blocks: List[str] = []
+    for i, m in enumerate(matches):
+        start = m.start()
+        end = matches[i + 1].start() if i + 1 < len(matches) else len(text)
+        chunk = text[start:end].strip()
+        if len(chunk) >= 40:
+            blocks.append(chunk)
+    return blocks
+
+
+def _ingestion_for_pdf(pdf: Path) -> Dict[str, Any]:
+    stem = pdf.stem
+    full = _extract_pdf_text(pdf)
+    chunks = split_pdf_text_into_questions(full)
+    questions = []
+    for i, chunk in enumerate(chunks):
+        questions.append(
+            {
+                "question_id": _stable_question_id(stem, i, chunk),
+                "start_page": None,
+                "page_nums": [],
+                "text": chunk,
+                "text_hash": None,
+                "image_crops": [],
+                "type": None,
+                "metadata": {"source": "exam_tests_pdf", "pdf": _pdf_relative_path(pdf)},
+            }
+        )
+    return {
+        "ingestion_id": f"ing_exam_tests_{stem}",
+        "created_at": None,
+        "source_pdf": _pdf_relative_path(pdf),
+        "exam_id": stem,
+        "questions": questions,
+    }
+
+
+def build_questions_db_from_exam_tests_dir(
+    directory: Optional[Path] = None,
+    *,
+    pdf_glob: str = "*.pdf",
+) -> Dict[str, Any]:
+    root = directory or EXAM_TESTS_DIR
+    if not root.is_dir():
+        return {"schema_version": "1.0", "ingestions": []}
+
+    pdfs = sorted(root.glob(pdf_glob), key=lambda p: p.name.lower())
+    ingestions: List[Dict[str, Any]] = []
+    for pdf in pdfs:
+        if not pdf.is_file():
+            continue
+        try:
+            ingestions.append(_ingestion_for_pdf(pdf))
+        except Exception:
+            # Skip unreadable PDFs; caller may log
+            continue
+    return {"schema_version": "1.0", "ingestions": ingestions}
+
+
+def load_questions_database(db_path: Optional[Path] = None) -> Dict[str, Any]:
+    """
+    If ``db_path`` is set, load that JSON file (ignores env / exam_tests PDFs).
+    Else if ``VARIANT_GEN_QUESTIONS_JSON`` is set in the environment, load it.
+    Otherwise build from ``exam_tests/*.pdf``.
+    """
+    if db_path is not None:
+        data = json.loads(Path(db_path).read_text(encoding="utf-8"))
+    else:
+        env_path = os.environ.get("VARIANT_GEN_QUESTIONS_JSON", "").strip()
+        if env_path:
+            data = json.loads(Path(env_path).read_text(encoding="utf-8"))
+        else:
+            data = build_questions_db_from_exam_tests_dir()
+    if not isinstance(data, dict) or "ingestions" not in data:
+        raise ValueError("Questions database must be a dict with an 'ingestions' list.")
+    return data

--- a/backend/app/variant_gen/generation_batch_runner.py
+++ b/backend/app/variant_gen/generation_batch_runner.py
@@ -1,0 +1,181 @@
+"""
+Full-ingestion batch: generate variants for all questions in one ingestion, append to
+exam_tests/variants.json (by default).
+
+From the server directory:
+
+  python -m variant_gen.generation_batch_runner
+  python -m variant_gen.generation_batch_runner --exam-id practice-final
+  python -m variant_gen.generation_batch_runner --ingestion 1
+
+``--exam-id`` picks the ingestion whose ``exam_id`` matches (last match wins if duplicated).
+Otherwise ``--ingestion`` is the 0-based index among ingestions (one per exam_tests PDF by default;
+``-1`` = last).
+
+Optional ``--db`` points at a layout ``questions.json`` export; default is PDFs in ``exam_tests/``.
+
+Or use VS Code / Cursor "Run Python File" on this module — the path bootstrap below makes that work.
+"""
+
+import argparse
+import json
+import os
+import sys
+import time
+from pathlib import Path
+
+if __name__ == "__main__":
+    _server_dir = Path(__file__).resolve().parent.parent
+    if str(_server_dir) not in sys.path:
+        sys.path.insert(0, str(_server_dir))
+
+from variant_gen import EXAM_TESTS_DIR, generate_variant
+from variant_gen.exam_tests_questions import load_questions_database
+from variant_gen.ingestion_resolve import resolve_ingestion_index
+
+OUTPUT_PATH = EXAM_TESTS_DIR / "variants.json"
+
+DEBUG_BATCH = False
+
+
+def load_json_safe(path):
+    if not path.exists():
+        return []
+    try:
+        with open(path, "r", encoding="utf-8") as f:
+            return json.load(f)
+    except (json.JSONDecodeError, UnicodeDecodeError):
+        return []
+
+
+def save_atomic(data, path):
+    temp_path = path.with_suffix(".tmp")
+    with open(temp_path, "w", encoding="utf-8") as f:
+        json.dump(data, f, indent=2, ensure_ascii=False)
+    os.replace(str(temp_path), str(path))
+
+
+def main():
+    ap = argparse.ArgumentParser(description="Batch variant generation for one ingestion.")
+    ap.add_argument(
+        "--db",
+        type=Path,
+        default=None,
+        help="optional questions.json path; default is exam_tests PDFs or VARIANT_GEN_QUESTIONS_JSON",
+    )
+    ap.add_argument(
+        "--ingestion",
+        type=int,
+        default=0,
+        help="0-based ingestion index (-1=last; default 0); ignored if --exam-id is set",
+    )
+    ap.add_argument(
+        "--exam-id",
+        default=None,
+        metavar="ID",
+        help="select ingestion by exam_id (exact match; last match wins); overrides --ingestion",
+    )
+    args = ap.parse_args()
+
+    try:
+        source_data = load_questions_database(args.db)
+    except (OSError, json.JSONDecodeError, ValueError) as e:
+        print(f"Error loading questions: {e}")
+        return
+
+    ingestions = source_data["ingestions"]
+    try:
+        ing_idx = resolve_ingestion_index(
+            ingestions,
+            exam_id=args.exam_id,
+            ingestion_index=args.ingestion,
+        )
+    except (ValueError, IndexError) as e:
+        print(f"Error: {e}")
+        return
+
+    active = ingestions[ing_idx]
+    questions = active["questions"]
+    print(
+        f"Ingestion [{ing_idx}] exam_id={active.get('exam_id', '?')} "
+        f"id={active.get('ingestion_id', '?')} source={active.get('source_pdf', '?')}"
+    )
+    total_questions = len(questions)
+
+    existing_results = load_json_safe(OUTPUT_PATH)
+    processed_ids = {item["original_id"] for item in existing_results}
+    results = list(existing_results)
+
+    print(f"Total Questions: {total_questions}")
+    print(f"Already Completed: {len(processed_ids)}")
+    print(f"Output: {OUTPUT_PATH}")
+    print("Starting Batch Generation...\n")
+    print("-" * 50)
+
+    stats = {"success": 0, "fail": 0, "skipped": len(processed_ids)}
+
+    for i, q in enumerate(questions):
+        q_id = q.get("question_id", f"index_{i}")
+        q_text = q.get("text", "")[:60].replace("\n", " ") + "..."
+
+        if not q.get("text"):
+            if DEBUG_BATCH:
+                print(f"   [Skip] Empty text at index {i}")
+            continue
+
+        if q_id in processed_ids:
+            if DEBUG_BATCH:
+                print(f"   [Skip] ID {q_id} already processed.")
+            continue
+
+        print(f"Processing [{i+1}/{total_questions}]: ID {q_id}")
+        print(f"   Context: \"{q_text}\"")
+
+        try:
+            start_time = time.time()
+
+            variant = generate_variant(
+                i,
+                db_path=args.db,
+                ingestion_index=ing_idx,
+                questions_db=source_data,
+            )
+
+            duration = time.time() - start_time
+
+            if variant:
+                print(f"   Success ({duration:.1f}s) [{variant.get('scenario_domain', '?')}]")
+                results.append(variant)
+                processed_ids.add(q_id)
+                stats["success"] += 1
+            else:
+                print(f"   Failed ({duration:.1f}s)")
+                stats["fail"] += 1
+
+            save_atomic(results, OUTPUT_PATH)
+
+            time.sleep(0.5)
+
+        except KeyboardInterrupt:
+            print("\nBatch stopped by user. Progress saved.")
+            save_atomic(results, OUTPUT_PATH)
+            break
+        except Exception as e:
+            print(f"   Critical Error: {e}")
+            stats["fail"] += 1
+            continue
+
+        print("-" * 50)
+
+    print("\n" + "=" * 40)
+    print("          BATCH COMPLETE")
+    print("=" * 40)
+    print(f"  New Successful:   {stats['success']}")
+    print(f"  Previously Done:  {stats['skipped']}")
+    print(f"  Failed/Skipped:   {stats['fail']}")
+    print(f"  Output Saved To:  {OUTPUT_PATH}")
+    print("=" * 40)
+
+
+if __name__ == "__main__":
+    main()

--- a/backend/app/variant_gen/generator.py
+++ b/backend/app/variant_gen/generator.py
@@ -1,0 +1,239 @@
+"""
+Orchestrates one variant: load question → classify → LLM generate → validate → LLM verify.
+
+Supporting modules:
+  ``config`` — paths, model names, thresholds.
+  ``question_inputs`` — skip/vision/format and coarse algorithm tag from raw text.
+  ``prompts`` — generation and verification prompt strings.
+  ``variant_validation`` — deterministic JSON checks and answer normalization.
+  ``llm_client`` — provider JSON calls.
+  ``exam_tests_questions`` — default question DB from PDFs (or env override).
+"""
+
+from pathlib import Path
+
+from .config import (
+    BASE_TEMPERATURE,
+    DEBUG,
+    MAX_RETRIES,
+    generation_source_max_chars,
+    openrouter_timeout_verify,
+    resolved_llm_model,
+    telemetry_enabled,
+    variant_llm_provider,
+)
+from .exam_tests_questions import load_questions_database
+from .llm_client import call_llm, text_model_supports_images
+from .prompts import build_generation_prompt, build_verify_prompt
+from .question_contract import scenario_from_contract
+from .question_inputs import (
+    extract_algorithm,
+    should_skip_question,
+    should_use_vision,
+)
+from .question_router import route_stem, telemetry_outcome_line, telemetry_routing_line
+from .variant_validation import (
+    autofix_list_method_mcq,
+    free_response_correct_answer_invalid,
+    is_invalid_variant,
+    is_too_similar,
+    normalize_answer,
+    similarity_threshold_for_original,
+)
+
+
+def _clip_text_for_generation(text: str, limit: int) -> str:
+    t = text or ""
+    if len(t) <= limit:
+        return t
+    head = (limit * 2) // 3
+    tail = limit - head - 80
+    if tail < 2000:
+        tail = 2000
+        head = limit - tail - 80
+    return t[:head] + "\n\n[... source truncated ...]\n\n" + t[-tail:]
+
+
+def generate_variant(index, db_path=None, ingestion_index=-1, questions_db=None):
+    """
+    ``db_path``: optional path to a questions.json-shaped file (layout output or export).
+    If omitted, questions come from ``exam_tests/*.pdf`` (or ``VARIANT_GEN_QUESTIONS_JSON``).
+    ``questions_db``: optional pre-loaded dict (same schema); avoids re-parsing in batch loops.
+    """
+    if questions_db is not None:
+        db = questions_db
+    elif db_path is not None:
+        db = load_questions_database(Path(db_path))
+    else:
+        db = load_questions_database(None)
+
+    ingestions = db["ingestions"]
+    if not ingestions:
+        print("No ingestions (add PDFs under exam_tests/ or set VARIANT_GEN_QUESTIONS_JSON).")
+        return None
+    try:
+        ing = ingestions[ingestion_index]
+    except IndexError:
+        print(
+            f"Ingestion index {ingestion_index} out of range "
+            f"(0-{len(ingestions) - 1}, or negative for from end)"
+        )
+        return None
+
+    questions = ing["questions"]
+    if index < 0 or index >= len(questions):
+        print(f"Index {index} out of range (0-{len(questions)-1})")
+        return None
+
+    q = questions[index]
+
+    if should_skip_question(q.get("text", "")):
+        print("Skipping: Detected as non-question (policy/instructions).")
+        return None
+
+    use_vision = should_use_vision(q)
+    image_paths = []
+    if use_vision and text_model_supports_images() and q.get("image_crops"):
+        image_paths = [q["image_crops"][0]]
+    elif use_vision and not text_model_supports_images() and DEBUG:
+        print(
+            "[DEBUG] Vision requested but variant vision is disabled; "
+            "using question text only."
+        )
+
+    algorithm = extract_algorithm(q.get("text", ""))
+    contract = route_stem(q.get("text", "") or "")
+    forced_type = contract.question_format
+    expected_mcq_options = contract.expected_mcq_options
+    provider_label = variant_llm_provider()
+    gen_label = resolved_llm_model(provider_label)
+    print(
+        f"Format: {forced_type} | Algorithm: {algorithm} | Mode: {contract.mode} | "
+        f"Lang: {contract.language} | Reskin: {contract.allow_thematic_reskin} | "
+        f"Route: {contract.routing_source} | LLM: {provider_label}/{gen_label}"
+    )
+    qid = q.get("question_id") or ""
+    if telemetry_enabled():
+        print(telemetry_routing_line(qid, contract), flush=True)
+
+    for attempt in range(1, MAX_RETRIES + 1):
+        temperature = BASE_TEMPERATURE + (attempt - 1) * 0.15
+        print(f"Attempt {attempt}/{MAX_RETRIES} (temp={temperature:.2f})...")
+
+        scenario = scenario_from_contract(contract)
+        label = scenario.get("domain") or scenario.get("theme", "?")
+        print(f"  Scenario: {label} ({scenario['style']})")
+
+        gen_prompt = build_generation_prompt(
+            _clip_text_for_generation(q.get("text", "") or "", generation_source_max_chars()),
+            forced_type,
+            scenario,
+            algorithm,
+            contract,
+        )
+        variant = call_llm(gen_prompt, image_paths=image_paths, temperature=temperature)
+        if not variant or "variant_text" not in variant:
+            print("  Generation returned null or missing variant_text.")
+            continue
+
+        if forced_type == "MCQ" and autofix_list_method_mcq(
+            variant, q.get("text", ""), contract.language
+        ):
+            print(f"  List-method MCQ: normalized correct_answer -> {variant.get('correct_answer')}")
+
+        bad = is_invalid_variant(
+            variant, forced_type, expected_mcq_options, q.get("text", ""), contract
+        )
+        if bad:
+            print(f"  Invalid variant: {bad}")
+            continue
+
+        if DEBUG:
+            print(f"[DEBUG] Variant text: {variant.get('variant_text')}")
+
+        sim_thresh = similarity_threshold_for_original(q["text"])
+        if is_too_similar(q["text"], variant["variant_text"]):
+            print(f"  Variant too similar to original (>{sim_thresh:.0%}), retrying.")
+            continue
+
+        gen_ans = str(variant.get("correct_answer", "")).strip()
+        if not gen_ans:
+            print("  Generator produced empty correct_answer.")
+            continue
+        late_fr = free_response_correct_answer_invalid(
+            gen_ans, variant, contract.language, contract, q.get("text", "")
+        )
+        if forced_type == "FREE_RESPONSE" and late_fr:
+            print(f"  Invalid correct_answer: {late_fr}")
+            continue
+
+        verify_prompt = build_verify_prompt(
+            variant["variant_text"],
+            variant.get("options"),
+            forced_type,
+            gen_ans,
+            contract,
+        )
+
+        solution = call_llm(
+            verify_prompt,
+            image_paths=None,
+            temperature=temperature,
+            timeout_sec=openrouter_timeout_verify(),
+        )
+        if not solution or "final_answer" not in solution:
+            print("  Solver returned null or missing final_answer.")
+            continue
+
+        if DEBUG:
+            print(f"[DEBUG] Solver answer: {solution.get('final_answer')}")
+
+        verified = False
+        if forced_type in ["MCQ", "TRUE_FALSE"]:
+            g_val = normalize_answer(gen_ans)
+            s_val = normalize_answer(solution["final_answer"])
+            if g_val == s_val:
+                verified = True
+            else:
+                print(f"  Mismatch: Generator='{g_val}' vs Solver='{s_val}'")
+        else:
+            verified = bool(solution.get("claimed_answer_is_correct"))
+            if not verified:
+                reason = solution.get("reasoning", "no reasoning provided")
+                print(f"  Verifier rejected: {reason[:120]}...")
+
+        if verified:
+            print(f"  Verified on attempt {attempt}")
+            if telemetry_enabled():
+                print(telemetry_outcome_line(qid, "verified", f"attempt={attempt}"), flush=True)
+            return {
+                "original_id": q.get("question_id"),
+                "source_ingestion_id": ing.get("ingestion_id"),
+                "source_ingestion_index": (
+                    ingestion_index
+                    if ingestion_index >= 0
+                    else len(ingestions) + ingestion_index
+                ),
+                "type": forced_type,
+                "language": contract.language,
+                "question_mode": contract.mode,
+                "routing": contract.routing_source,
+                "algorithm": algorithm,
+                "storyline": variant.get("storyline", ""),
+                "task": variant.get("task", ""),
+                "constraints": variant.get("constraints", ""),
+                "question": variant["variant_text"],
+                "options": variant.get("options"),
+                "answer": gen_ans,
+                "scenario_domain": scenario.get("domain") or scenario.get("theme"),
+                "scenario_style": scenario["style"],
+            }
+
+    print(f"Failed verification after {MAX_RETRIES} attempts")
+    if telemetry_enabled():
+        print(telemetry_outcome_line(qid, "failed_all_retries", ""), flush=True)
+    return None
+
+
+if __name__ == "__main__":
+    generate_variant(3)

--- a/backend/app/variant_gen/ingestion_resolve.py
+++ b/backend/app/variant_gen/ingestion_resolve.py
@@ -1,0 +1,36 @@
+"""Resolve which ingestion block to use in the questions database (layout JSON or exam_tests PDFs)."""
+
+from typing import Any, Dict, List, Optional
+
+
+def resolve_ingestion_index(
+    ingestions: List[Dict[str, Any]],
+    *,
+    exam_id: Optional[str] = None,
+    ingestion_index: int = 0,
+) -> int:
+    """Return a 0-based index into ``ingestions``.
+
+    If ``exam_id`` is set, match ``ing["exam_id"]`` exactly (after strip). If several
+    match, the **last** occurrence in file order wins. Otherwise ``ingestion_index``
+    uses normal list semantics, including negatives (``-1`` = last).
+    """
+    if not ingestions:
+        raise IndexError("questions.json has no ingestions")
+
+    if exam_id is not None:
+        key = exam_id.strip()
+        if not key:
+            raise ValueError("exam_id must be non-empty when provided")
+        hits = [i for i, ing in enumerate(ingestions) if (ing.get("exam_id") or "") == key]
+        if not hits:
+            raise ValueError(f"no ingestion with exam_id={key!r}")
+        return hits[-1]
+
+    n = len(ingestions)
+    idx = ingestion_index if ingestion_index >= 0 else n + ingestion_index
+    if idx < 0 or idx >= n:
+        raise IndexError(
+            f"ingestion index {ingestion_index} out of range for {n} ingestion(s)"
+        )
+    return idx

--- a/backend/app/variant_gen/llm_client.py
+++ b/backend/app/variant_gen/llm_client.py
@@ -1,0 +1,254 @@
+"""LLM chat calls for generate + verify steps; JSON in/out."""
+
+import base64
+import json
+import os
+import re
+import time
+from pathlib import Path
+from typing import Any, Dict, List, Optional, Union
+
+import requests
+from requests.exceptions import ConnectionError as RequestsConnectionError
+from requests.exceptions import SSLError
+
+from .config import (
+    BASE_TEMPERATURE,
+    DEBUG,
+    GEMINI_URL_TEMPLATE,
+    OPENROUTER_URL,
+    openrouter_timeout_generate,
+    resolved_gemini_model,
+    resolved_openrouter_model,
+    variant_llm_provider,
+    variant_vision_enabled,
+)
+
+_IMAGE_MIME = {
+    ".png": "image/png",
+    ".jpg": "image/jpeg",
+    ".jpeg": "image/jpeg",
+    ".gif": "image/gif",
+    ".webp": "image/webp",
+}
+
+
+def encode_image(path: Union[Path, str], data_url: bool = False) -> Optional[str]:
+    p = Path(path)
+    if not p.exists():
+        return None
+    with open(p, "rb") as f:
+        b64 = base64.b64encode(f.read()).decode("ascii")
+    if not data_url:
+        return b64
+    mime = _IMAGE_MIME.get(p.suffix.lower(), "image/png")
+    return f"data:{mime};base64,{b64}"
+
+
+def parse_llm_json(content: Optional[str]) -> Optional[Dict[str, Any]]:
+    if not content or not isinstance(content, str):
+        return None
+    s = content.strip()
+    if s.startswith("```"):
+        s = re.sub(r"^```(?:json)?\s*", "", s, flags=re.IGNORECASE)
+        s = re.sub(r"\s*```\s*$", "", s)
+    try:
+        return json.loads(s)
+    except json.JSONDecodeError as e:
+        print(f"  Model returned invalid JSON: {e}")
+        if DEBUG:
+            print(f"[DEBUG] Raw content was: {content[:2000]}")
+        return None
+
+
+def _openrouter_chat(
+    prompt: str,
+    image_paths: List[Path],
+    temp: float,
+    model: str,
+    timeout_sec: float,
+) -> Optional[Dict[str, Any]]:
+    key = os.getenv("OPENROUTER_API_KEY", "").strip()
+    if not key:
+        print("  OPENROUTER_API_KEY is not set.")
+        return None
+
+    if image_paths:
+        parts: List[Dict[str, Any]] = [{"type": "text", "text": prompt}]
+        for p in image_paths:
+            url = encode_image(p, data_url=True)
+            if url:
+                parts.append({"type": "image_url", "image_url": {"url": url}})
+        user_content: Any = parts
+    else:
+        user_content = prompt
+
+    headers = {
+        "Authorization": f"Bearer {key}",
+        "Content-Type": "application/json",
+    }
+    ref = os.getenv("OPENROUTER_HTTP_REFERER", "").strip()
+    if ref:
+        headers["HTTP-Referer"] = ref
+    title = os.getenv("OPENROUTER_APP_TITLE", "").strip()
+    if title:
+        headers["X-Title"] = title
+
+    payload = {
+        "model": model,
+        "messages": [{"role": "user", "content": user_content}],
+        "temperature": temp,
+        "response_format": {"type": "json_object"},
+    }
+    connect_s = min(20.0, max(5.0, timeout_sec * 0.25))
+    max_attempts = max(1, int(os.getenv("OPENROUTER_HTTP_RETRIES", "3")))
+    for attempt in range(max_attempts):
+        try:
+            response = requests.post(
+                OPENROUTER_URL,
+                json=payload,
+                headers=headers,
+                timeout=(connect_s, timeout_sec),
+            )
+            if not response.ok:
+                try:
+                    err = response.json()
+                    detail = err.get("error", err)
+                except Exception:
+                    detail = response.text[:500]
+                print(f"  OpenRouter HTTP {response.status_code}: {detail}")
+                return None
+            data = response.json()
+            content = (data.get("choices") or [{}])[0].get("message", {}).get("content")
+            if DEBUG:
+                print(f"[DEBUG] Raw response: {content}")
+            return parse_llm_json(content)
+        except requests.Timeout:
+            print(f"  Request timed out ({timeout_sec:.0f}s).")
+            return None
+        except (SSLError, RequestsConnectionError) as e:
+            if attempt + 1 >= max_attempts:
+                print(f"  Unexpected error: {type(e).__name__}: {e}")
+                return None
+            delay = min(8.0, 0.6 * (2**attempt))
+            print(
+                f"  Transient network/TLS error ({type(e).__name__}), "
+                f"retry {attempt + 2}/{max_attempts} in {delay:.1f}s..."
+            )
+            time.sleep(delay)
+        except Exception as e:
+            print(f"  Unexpected error: {type(e).__name__}: {e}")
+            return None
+    return None
+
+
+def _gemini_chat(
+    prompt: str,
+    image_paths: List[Path],
+    temp: float,
+    model: str,
+    timeout_sec: float,
+) -> Optional[Dict[str, Any]]:
+    key = os.getenv("GEMINI_API_KEY", os.getenv("GOOGLE_API_KEY", "")).strip()
+    if not key:
+        print("  GEMINI_API_KEY is not set.")
+        return None
+
+    parts: List[Dict[str, Any]] = [{"text": prompt}]
+    for p in image_paths:
+        data = encode_image(p, data_url=False)
+        if data:
+            mime = _IMAGE_MIME.get(p.suffix.lower(), "image/png")
+            parts.append({"inline_data": {"mime_type": mime, "data": data}})
+
+    payload = {
+        "contents": [{"role": "user", "parts": parts}],
+        "generationConfig": {
+            "temperature": temp,
+            "response_mime_type": "application/json",
+        },
+    }
+    url = GEMINI_URL_TEMPLATE.format(model=model)
+    headers = {"Content-Type": "application/json", "x-goog-api-key": key}
+    connect_s = min(20.0, max(5.0, timeout_sec * 0.25))
+    retry_env = os.getenv("VARIANT_LLM_HTTP_RETRIES", os.getenv("OPENROUTER_HTTP_RETRIES", "3"))
+    max_attempts = max(1, int(retry_env))
+
+    for attempt in range(max_attempts):
+        try:
+            response = requests.post(
+                url,
+                json=payload,
+                headers=headers,
+                timeout=(connect_s, timeout_sec),
+            )
+            if not response.ok:
+                try:
+                    err = response.json()
+                    detail = err.get("error", err)
+                except Exception:
+                    detail = response.text[:500]
+                print(f"  Gemini HTTP {response.status_code}: {detail}")
+                return None
+
+            data = response.json()
+            candidates = data.get("candidates") or []
+            content = ""
+            if candidates:
+                parts_out = candidates[0].get("content", {}).get("parts") or []
+                content = "\n".join(
+                    str(part.get("text", ""))
+                    for part in parts_out
+                    if isinstance(part, dict) and part.get("text")
+                )
+            if DEBUG:
+                print(f"[DEBUG] Raw Gemini response: {content}")
+            return parse_llm_json(content)
+        except requests.Timeout:
+            print(f"  Request timed out ({timeout_sec:.0f}s).")
+            return None
+        except (SSLError, RequestsConnectionError) as e:
+            if attempt + 1 >= max_attempts:
+                print(f"  Unexpected error: {type(e).__name__}: {e}")
+                return None
+            delay = min(8.0, 0.6 * (2**attempt))
+            print(
+                f"  Transient network/TLS error ({type(e).__name__}), "
+                f"retry {attempt + 2}/{max_attempts} in {delay:.1f}s..."
+            )
+            time.sleep(delay)
+        except Exception as e:
+            print(f"  Unexpected error: {type(e).__name__}: {e}")
+            return None
+    return None
+
+
+def call_llm(
+    prompt: str,
+    *,
+    image_paths: Optional[List[Union[Path, str]]] = None,
+    temperature: Optional[float] = None,
+    model: Optional[str] = None,
+    timeout_sec: Optional[float] = None,
+) -> Optional[Dict[str, Any]]:
+    """Generate or verify: JSON object in, JSON object out."""
+    paths = [Path(x) for x in (image_paths or []) if x]
+    temp = temperature if temperature is not None else BASE_TEMPERATURE
+    provider = variant_llm_provider()
+    if provider == "gemini":
+        mid = model or resolved_gemini_model()
+    elif provider == "openrouter":
+        mid = model or resolved_openrouter_model()
+    else:
+        print(f"  Unsupported VARIANT_LLM_PROVIDER: {provider}")
+        return None
+    to = float(timeout_sec) if timeout_sec is not None else openrouter_timeout_generate()
+    if DEBUG:
+        print(f"\n[DEBUG] Calling {provider} model: {mid} (timeout {to:.0f}s)")
+    if provider == "gemini":
+        return _gemini_chat(prompt, paths, temp, mid, to)
+    return _openrouter_chat(prompt, paths, temp, mid, to)
+
+
+def text_model_supports_images() -> bool:
+    return variant_vision_enabled()

--- a/backend/app/variant_gen/milestone_one_adapter.py
+++ b/backend/app/variant_gen/milestone_one_adapter.py
@@ -1,0 +1,170 @@
+"""Adapt Milestone 1 database questions into variant_gen's ingestion shape."""
+
+from __future__ import annotations
+
+import json
+import re
+from datetime import datetime
+from typing import Any, Iterable, Optional
+
+
+_LABELS = "ABCDEFGHIJKLMNOPQRSTUVWXYZ"
+
+
+def _safe_json_loads(raw: Any, default: Any) -> Any:
+    if raw is None:
+        return default
+    if isinstance(raw, (list, dict)):
+        return raw
+    try:
+        return json.loads(str(raw))
+    except (TypeError, ValueError, json.JSONDecodeError):
+        return default
+
+
+def _clean_identifier(value: Any, fallback: str) -> str:
+    text = str(value or "").strip() or fallback
+    text = re.sub(r"[^A-Za-z0-9_.:-]+", "_", text)
+    return text.strip("_") or fallback
+
+
+def _iso_or_none(value: Any) -> Optional[str]:
+    if isinstance(value, datetime):
+        return value.isoformat()
+    return None
+
+
+def _question_type(question: Any) -> str:
+    return str(getattr(question, "question_type", "") or "").strip().lower()
+
+
+def _text_has_labeled_choices(text: str) -> bool:
+    if not text:
+        return False
+    patterns = (
+        r"(?m)^\s*[A-E][\.\)]\s+\S",
+        r"(?m)^\s*\(\s*[a-e]\s*\)\s+\S",
+        r"(?m)^\s*[1-5][\.\)]\s+\S",
+    )
+    return any(len(re.findall(pattern, text)) >= 2 for pattern in patterns)
+
+
+def _choice_text(choice: Any) -> str:
+    if choice is None:
+        return ""
+    if isinstance(choice, (str, int, float, bool)):
+        return str(choice).strip()
+    if isinstance(choice, dict):
+        for key in ("text", "choice", "answer", "value", "label"):
+            val = choice.get(key)
+            if val is not None and str(val).strip():
+                return str(val).strip()
+        try:
+            return json.dumps(choice, ensure_ascii=False)
+        except TypeError:
+            return str(choice)
+    if isinstance(choice, (list, tuple)):
+        return ", ".join(part for part in (_choice_text(x) for x in choice) if part)
+    return str(choice).strip()
+
+
+def _choice_label(choice: Any, index: int) -> str:
+    if isinstance(choice, dict):
+        raw = choice.get("label") or choice.get("key")
+        label = str(raw or "").strip()
+        if label and len(label) <= 3:
+            return label.rstrip(".):")
+    return _LABELS[index] if index < len(_LABELS) else str(index + 1)
+
+
+def _format_choices_block(choices: Iterable[Any]) -> str:
+    lines = []
+    for i, choice in enumerate(choices):
+        text = _choice_text(choice)
+        if not text:
+            continue
+        label = _choice_label(choice, i)
+        lines.append(f"{label}. {text}")
+    if len(lines) < 2:
+        return ""
+    return "Options:\n" + "\n".join(lines)
+
+
+def source_text_for_variant_generation(question: Any) -> str:
+    """
+    Build the source stem sent to variant_gen.
+
+    Milestone 1 often stores MCQ options separately from ``Question.text``. The
+    stem router only sees text, so append answer choices for MCQ-like rows when
+    they are not already embedded in the question body.
+    """
+    text = str(getattr(question, "text", "") or "").strip()
+    qtype = _question_type(question)
+
+    if qtype in {"mcq", "multiple_choice", "multiple choice"} and not _text_has_labeled_choices(text):
+        choices = _safe_json_loads(getattr(question, "answer_choices", "[]"), [])
+        if isinstance(choices, list):
+            block = _format_choices_block(choices)
+            if block:
+                return f"{text}\n\n{block}".strip()
+
+    if qtype in {"true_false", "true/false", "tf"}:
+        tl = text.lower()
+        if "true" not in tl or "false" not in tl:
+            return f"{text}\n\nAnswer True or False.".strip()
+
+    return text
+
+
+def question_to_variant_gen_question(question: Any) -> dict[str, Any]:
+    """Return the single-question record expected inside a variant_gen ingestion."""
+    db_id = getattr(question, "id", None)
+    qid = getattr(question, "qid", None)
+    stable_id = _clean_identifier(qid or db_id, "unknown")
+    return {
+        "question_id": f"caliber_{stable_id}",
+        "start_page": None,
+        "page_nums": [],
+        "text": source_text_for_variant_generation(question),
+        "text_hash": None,
+        # Milestone 1 stores image_url as a storage path/URL, not a local crop file.
+        # Keep this empty until the API endpoint has a safe download/signing step.
+        "image_crops": [],
+        "type": getattr(question, "question_type", None),
+        "metadata": {
+            "source": "caliber_milestone_one_db",
+            "caliber_id": db_id,
+            "caliber_qid": qid,
+            "title": getattr(question, "title", "") or "",
+            "course": getattr(question, "course", "") or "",
+            "course_type": getattr(question, "course_type", "") or "",
+            "school": getattr(question, "school", "") or "",
+            "blooms_taxonomy": getattr(question, "blooms_taxonomy", "") or "",
+            "source_pdf": getattr(question, "source_pdf", None),
+            "image_url": getattr(question, "image_url", None),
+        },
+    }
+
+
+def question_to_variant_gen_db(question: Any) -> dict[str, Any]:
+    """
+    Wrap one Milestone 1 question row in the questions.json-shaped DB.
+
+    The returned object can be passed directly to
+    ``generate_variant(0, ingestion_index=0, questions_db=...)``.
+    """
+    db_id = getattr(question, "id", None)
+    qid = getattr(question, "qid", None)
+    stable_id = _clean_identifier(qid or db_id, "unknown")
+    return {
+        "schema_version": "1.0",
+        "ingestions": [
+            {
+                "ingestion_id": f"ing_caliber_{stable_id}",
+                "created_at": _iso_or_none(getattr(question, "created_at", None)),
+                "source_pdf": getattr(question, "source_pdf", None),
+                "exam_id": f"caliber_question_{stable_id}",
+                "questions": [question_to_variant_gen_question(question)],
+            }
+        ],
+    }

--- a/backend/app/variant_gen/policies/__init__.py
+++ b/backend/app/variant_gen/policies/__init__.py
@@ -1,0 +1,13 @@
+"""Language/course-specific policy hooks for variant generation.
+
+Keep generator invariants generic; put language- or course-specific rules here.
+"""
+
+from .python_intro import PythonIntroPolicy
+
+
+def get_policy(language: str):
+    if language == "python":
+        return PythonIntroPolicy()
+    return None
+

--- a/backend/app/variant_gen/policies/python_intro.py
+++ b/backend/app/variant_gen/policies/python_intro.py
@@ -1,0 +1,148 @@
+import ast
+import re
+from typing import Optional
+
+
+class PythonIntroPolicy:
+    """Python-intro specific invariants and autofixes."""
+
+    LIST_METHOD_NAMES = frozenset(
+        {
+            "append",
+            "clear",
+            "copy",
+            "count",
+            "extend",
+            "index",
+            "insert",
+            "pop",
+            "remove",
+            "reverse",
+            "sort",
+        }
+    )
+
+    @staticmethod
+    def original_suggests_list_method_mcq(original_text: str) -> bool:
+        t = (original_text or "").lower()
+        if not re.search(r"(?:^|\n|\s)(?:[A-E]|[1-5])[\.\)]\s+\w+", original_text or ""):
+            return False
+        # "method reverseList(head)" on a linked list is not a built-in list.append-style MCQ.
+        if re.search(r"linked[\s-]*list|singly[\s-]*linked", t):
+            return False
+        compact = re.sub(r"\s+", "", t)
+        if "reverselist" in compact:
+            return False
+        return (
+            "list method" in t
+            or "elements to a list" in t
+            or ("to a list" in t and "method" in t)
+            or (
+                "method" in t
+                and "list" in t
+                and "linked" not in t
+            )
+        )
+
+    @staticmethod
+    def stem_asks_for_non_method(stem_lower: str) -> bool:
+        s = stem_lower or ""
+        if "method" not in s or not re.search(r"\bnot\b", s):
+            return False
+        if re.search(r"\bnot\s+a\s+list\s+method\b", s):
+            return True
+        if re.search(r"\bnot\b.?\s*(one\s+of\s+)?the\s+following", s):
+            return True
+        if re.search(r"which\b.*\bnot\b.*\bmethod\b", s):
+            return True
+        return False
+
+    def list_method_mcq_autofix(self, variant: dict, original_text: str, normalize_answer, mcq_correct_option_label) -> bool:
+        """If exactly one option is (non-)method, set correct_answer accordingly."""
+        if not self.original_suggests_list_method_mcq(original_text):
+            return False
+        opts = variant.get("options")
+        if not opts or not isinstance(opts, dict):
+            return False
+        vt = (variant.get("variant_text") or "").lower()
+        old = str(variant.get("correct_answer", "")).strip()
+
+        neg = self.stem_asks_for_non_method(vt)
+        if neg:
+            bad = [
+                k
+                for k, v in opts.items()
+                if str(v).strip().lower() not in self.LIST_METHOD_NAMES
+            ]
+            if len(bad) != 1:
+                return False
+            pick = str(bad[0]).strip()
+        else:
+            good = [
+                k
+                for k, v in opts.items()
+                if str(v).strip().lower() in self.LIST_METHOD_NAMES
+            ]
+            if len(good) != 1:
+                return False
+            pick = str(good[0]).strip()
+
+        # If options are 1–5 but answer is A–E, normalize.
+        variant["correct_answer"] = normalize_answer(pick)
+        return normalize_answer(old) != normalize_answer(variant["correct_answer"])
+
+    def validate_list_method_mcq(self, variant: dict, original_text: str, vt_lower: str, mcq_correct_option_label) -> Optional[str]:
+        if not self.original_suggests_list_method_mcq(original_text):
+            return None
+        opts = variant.get("options")
+        if not opts or not isinstance(opts, dict):
+            return None
+        real = [k for k, v in opts.items() if str(v).strip().lower() in self.LIST_METHOD_NAMES]
+        fake = [k for k, v in opts.items() if str(v).strip().lower() not in self.LIST_METHOD_NAMES]
+        if not real:
+            return "list-method MCQ: at least one option must be a real Python list method"
+        neg = self.stem_asks_for_non_method(vt_lower)
+        if neg and len(fake) != 1:
+            return f"list-method MCQ: expected exactly 1 non-method option, got {len(fake)}"
+        if not neg and len(real) != 1:
+            return f"list-method MCQ: expected exactly 1 real list method option, got {len(real)}"
+
+        lab, opt_txt = mcq_correct_option_label(variant.get("correct_answer"), opts)
+        if lab and opt_txt is not None:
+            if neg and opt_txt in self.LIST_METHOD_NAMES:
+                return "stem asks which is NOT a list method but correct_answer picks a real method"
+            if not neg and opt_txt not in self.LIST_METHOD_NAMES:
+                return "stem asks for a list method but correct_answer is not a list method"
+        return None
+
+    @staticmethod
+    def extract_python_for_parse(s: str) -> str:
+        if not s:
+            return ""
+        m = re.search(r"```(?:python)?\s*(.*?)```", s, re.DOTALL | re.IGNORECASE)
+        if m:
+            return m.group(1).strip()
+        return s.strip()
+
+    def answer_parseable(self, answer: str) -> bool:
+        code = self.extract_python_for_parse(answer)
+        if "def " not in code and "class " not in code:
+            return True
+        try:
+            ast.parse(code)
+            return True
+        except SyntaxError:
+            return False
+
+    def answer_has_mutable_defaults(self, answer: str) -> bool:
+        code = self.extract_python_for_parse(answer)
+        return bool(
+            re.search(r"def\s+\w+\s*\([^)]*=\s*\[\s*\]", code)
+            or re.search(r"def\s+\w+\s*\([^)]*=\s*\{\s*\}", code)
+        )
+
+    @staticmethod
+    def original_shows_mutable_defaults(original_text: str) -> bool:
+        o = original_text or ""
+        return bool(re.search(r"=\s*\[\s*\]", o) or re.search(r"=\s*\{\s*\}", o))
+

--- a/backend/app/variant_gen/prompts.py
+++ b/backend/app/variant_gen/prompts.py
@@ -1,0 +1,357 @@
+"""LLM system/user strings for variant generation and verification."""
+
+import json
+from typing import Any, Dict, Optional
+
+from .config import verify_variant_text_max_chars
+from .question_contract import (
+    QuestionContract,
+    fence_lang,
+    language_display,
+    looks_like_named_function_write_task,
+)
+from .question_inputs import count_options
+from .variant_validation import original_asks_for_code_submission
+
+
+def _verify_output_only_hint(variant_text: str) -> str:
+    """Extra verify instructions when the stem is clearly 'what is the output' style."""
+    t = (variant_text or "").lower()
+    if not any(
+        p in t
+        for p in (
+            "what is the output",
+            "what is the exact output",
+            "exact output of",
+            "output when the following",
+            "output when the code",
+            "output of the following",
+            "output of the program",
+            "when the following code",
+            "when the following program",
+            "when executed",
+            "when run",
+            "indicate the output",
+        )
+    ):
+        return ""
+    return """OUTPUT-ONLY: If the question asks only for printed or literal program output (not writing new code),
+compare claimed_answer to your computed result. Set claimed_answer_is_correct true if they match in substance
+after trimming leading and trailing whitespace. Minor formatting (extra spaces or newlines) is fine.
+Do not mark false because claimed_answer is brief. If values, line order, or shown literals disagree, mark false.
+
+"""
+
+
+def _truncate_for_verify_block(s: str, max_chars: int) -> str:
+    s = (s or "").strip()
+    if len(s) <= max_chars:
+        return s
+    head = max(2000, max_chars // 2 - 60)
+    tail = max_chars - head - 140
+    if tail < 800:
+        tail = 800
+        head = max(2000, max_chars - tail - 140)
+    return (
+        s[:head]
+        + f"\n\n[... omitted {len(s) - head - tail} characters from middle of question ...]\n\n"
+        + s[-tail:]
+    )
+
+
+def prompt_extras(original_text: str, forced_type: str, style: str, contract: QuestionContract) -> str:
+    t = (original_text or "").lower()
+    lang = contract.language
+    chunks = []
+
+    if forced_type == "MCQ" and lang == "python":
+        list_api = (
+            "list method" in t
+            or ("method" in t and "list" in t)
+            or "elements to a list" in t
+            or ("to a list" in t and "method" in t)
+        )
+        if list_api:
+            chunks.append(
+                "Python LIST API: say clearly the choices are Python built-in list methods. "
+                "Each option must be a real list method name "
+                "(append, extend, pop, insert, remove, clear, sort, reverse, copy, count, index). "
+                "No fake names (merge, add_friends, combine). If the original asks which is NOT a method, "
+                "correct_answer must be the letter for an option that is not a list method."
+            )
+        elif "dict" in t and "method" in t:
+            chunks.append(
+                "Python DICT API: options must be real dict methods; no invented names."
+            )
+        elif "set" in t and "method" in t:
+            chunks.append(
+                "Python SET API: options must be real set methods; no invented names."
+            )
+    elif forced_type == "MCQ" and lang == "cpp" and "vector" in t and "method" in t:
+        chunks.append(
+            "C++: if asking about std::vector member functions, options must be real vector API names "
+            "for the standard used in the course."
+        )
+
+    if forced_type == "FREE_RESPONSE":
+        if contract.mode == "conceptual":
+            chunks.append(
+                f"CONCEPTUAL: stay in {language_display(lang)} and CS ideas from the original; theme is only a hook. "
+                "Do not replace with unrelated domains. Do not put the full solution in variant_text or task."
+            )
+            if not original_asks_for_code_submission(original_text or ""):
+                chunks.append(
+                    "The original asks for explanation or comparison only — do NOT turn it into a coding exercise "
+                    "(e.g. do not add 'write a function' or require implementation) unless the source explicitly "
+                    "asked for code."
+                )
+        elif contract.mode == "algorithmic" and not contract.allow_thematic_reskin:
+            chunks.append(
+                "MULTI-STEP / STRUCTURE TASK: Stay in normal CS and data-structure vocabulary. "
+                "Do not wrap the problem in an unrelated real-world metaphor. "
+                "Preserve every requirement to show intermediate states, diagrams, or step-by-step structure "
+                "as clearly as in the original (same level of detail)."
+            )
+        if looks_like_named_function_write_task(original_text or ""):
+            chunks.append(
+                f"NAMED FUNCTION: Keep the required function name and parameter types as in the prompt. "
+                f"correct_answer must be complete {language_display(lang)} that satisfies the spec—no language mix-ups."
+            )
+        code_in_stem = any(
+            k in t
+            for k in (
+                "write a function",
+                "write a class",
+                "recursive function",
+                "write pseudocode",
+            )
+        ) or "def " in (original_text or "") or "void " in (original_text or "")
+        oop_fr = contract.mode == "class_design" and lang == "python"
+        if oop_fr:
+            fence = fence_lang(lang)
+            chunks.append(
+                "INGEST MAY INCLUDE THE ANSWER KEY BELOW THE PROMPT: The original often pastes the full solution. "
+                "variant_text must be the STUDENT-FACING question only—requirements in prose or short bullets. "
+                "Do NOT copy class/method bodies from the solution into variant_text, storyline, or task; "
+                "put the complete working code ONLY in correct_answer. "
+                f"If a starter is essential, use at most one ```{fence}``` block with `pass` or `...` only, "
+                "not the real implementation."
+            )
+        elif code_in_stem:
+            fence = fence_lang(lang)
+            chunks.append(
+                f"Put code in variant_text inside ```{fence} ... ``` with normal line breaks and indentation."
+            )
+        if lang == "python" and (style == "swe" or "class named" in t or "write a class" in t):
+            chunks.append(
+                "OOP correct_answer: no mutable defaults (def f(self, a=[], b={})); use None in __init__ "
+                "unless the original clearly shows that pattern."
+            )
+
+    if not chunks:
+        return ""
+    return "\nEXTRA RULES (from original):\n" + "\n".join(f"{i}. {c}" for i, c in enumerate(chunks, start=1))
+
+
+def build_generation_prompt(
+    original_text: str,
+    forced_type: str,
+    scenario: Dict[str, Any],
+    algorithm: str,
+    contract: QuestionContract,
+) -> str:
+    style = scenario.get("style", "reskin")
+    lang = contract.language
+    ld = language_display(lang)
+
+    if style == "swe":
+        context_block = f"""SCENARIO TO USE:
+- Domain: {scenario["domain"]}
+- Setting: {scenario["context"]}
+- Use entities like: {", ".join(scenario["entities"])}
+
+Rename classes, methods, and attributes to fit the domain naturally.
+For example, a "Book" class might become a "Deployment" class; a "Library" might become a "ServiceRegistry"."""
+    elif style == "conceptual":
+        context_block = f"""VARIANT STYLE — CONCEPTUAL (definition / compare / name-at-least-N):
+- The original tests CS knowledge (types, language rules, complexity, data structures, etc.).
+- Keep the SAME technical subject: if it asks about sequences, lists, tuples, or strings, the variant
+  must still be about those ideas in {ld} (or the same language as the original).
+- You may add a one-sentence hook, but do NOT reframe the question into a non-CS domain
+  (no parking lots, recipes, sports teams, travel, etc.).
+- Preserve technical vocabulary students must use (e.g. sequence, tuple, immutable)."""
+    else:
+        context_block = f"""THEME TO USE: {scenario["theme"]}
+- Swap abstract variables and entities for: {scenario["swap_nouns"]}
+- Example of this style: {scenario["example"]}
+
+Keep the problem structure almost identical to the original. Just replace the abstract
+nouns/numbers with concrete, tangible things from the theme. Think of it like a word-problem
+reskin: "find two numbers that sum to target" becomes "find two packages whose weights
+add up to the truck's capacity"."""
+
+    extras = prompt_extras(original_text, forced_type, style, contract)
+
+    format_rules = ""
+    if forced_type == "MCQ":
+        n_opts = count_options(original_text) or 4
+        lang_mcq = (
+            "If testing library/container methods, name the type (e.g. Python list, std::vector, Java ArrayList) "
+            "and use only real API names from that language."
+            if lang != "generic"
+            else "Use real API names for the language implied by the original."
+        )
+        format_rules = f"""
+FORMAT CONSTRAINTS (MCQ):
+- Keep the EXACT same question direction. If the original asks "which IS", ask "which IS".
+  If it asks "which is NOT", ask "which is NOT". Do NOT flip it.
+- Produce exactly {n_opts} options, labeled with the same scheme as the original.
+- {lang_mcq}
+- One option must be clearly correct; distractors should be plausible but wrong."""
+    elif forced_type == "TRUE_FALSE":
+        format_rules = """
+FORMAT CONSTRAINTS (TRUE/FALSE):
+- The statement must be clearly true or false with no ambiguity.
+- Keep the same truth value as the original if possible."""
+    else:
+        format_rules = f"""
+FORMAT CONSTRAINTS (FREE RESPONSE):
+- If the original asks to write a function, the variant must ask to write a function.
+- If the original asks to write a class, the variant must ask to write a class.
+- If the original asks for an explanation, the variant must ask for an explanation.
+- Preserve the same level of detail expected in the answer.
+- correct_answer MUST be non-empty.
+- If the question asks for code, correct_answer must be valid {ld} source (not prose about what it "should" do).
+- If the question asks for a prose explanation, correct_answer must be a concrete model answer (real sentences),
+  not grading instructions (never start with "The student should" or "The correct answer should").
+- Do not put the full model answer in variant_text or task; only correct_answer holds it."""
+
+    return f"""You are creating a variant of a CS exam question. The variant should feel like a
+concrete, real-world scenario — not an abstract math or textbook exercise.
+
+TARGET LANGUAGE: {ld}. All code, API names, and syntax in the variant must match this language.
+
+ORIGINAL QUESTION:
+\"\"\"{original_text}\"\"\"
+
+CORE ALGORITHM: {algorithm}
+This algorithmic structure MUST be preserved in the variant. Do not change what kind of
+algorithm is needed to solve it.
+
+{context_block}
+{format_rules}
+{extras}
+
+STRUCTURAL RULES:
+1. The variant must test the SAME concept, at the SAME difficulty, using the SAME question
+   format as the original. Only the theme/nouns/values change.
+2. The underlying algorithm ({algorithm}) must remain the same.
+3. Replace generic variables (x, y, n, a, b) with descriptive names from the theme.
+4. The problem should read like a real situation someone might actually encounter.
+5. If the original has code, the variant must too — use fitting function/class names.
+6. You MUST produce a "{forced_type}" question.
+7. Do NOT mention the original question or call this a "variant".
+8. NEVER paste schema instructions into fields. Every string field must be real exam prose
+   a student would read — not phrases like "1-2 sentence scenario" or "full problem statement".
+9. Keep variant_text and options reasonably compact (avoid repeating the same code block many times);
+   downstream verification must fit in a single JSON object.
+
+OUTPUT JSON (shape only — replace values with your own complete text):
+{{
+    "type": "{forced_type}",
+    "storyline": "<brief real-world hook, 1-2 sentences>",
+    "task": "<what the student must compute or implement>",
+    "constraints": "<rules from the original, or empty string>",
+    "variant_text": "<entire question: hook + task + constraints; coherent and self-contained>",
+    "options": {{"A": "...", "B": "...", ...}} or null,
+    "correct_answer": "<single correct answer string>"
+}}"""
+
+
+def build_verify_prompt(
+    variant_text: str,
+    options: Optional[Dict[str, Any]],
+    forced_type: str,
+    claimed_answer: str,
+    contract: QuestionContract,
+) -> str:
+    ld = language_display(contract.language)
+    vlim = verify_variant_text_max_chars()
+    vt = _truncate_for_verify_block(variant_text, vlim)
+    trunc_note = (
+        "\nNOTE: Question text above may be truncated for size; solve from what is shown.\n"
+        if len(variant_text or "") > vlim
+        else ""
+    )
+    if forced_type in ("MCQ", "TRUE_FALSE"):
+        # Avoid hard-coding A–E: some sources legitimately use more labels.
+        allowed = None
+        if forced_type == "MCQ" and options and isinstance(options, dict):
+            labels = [str(k).strip() for k in options.keys() if str(k).strip()]
+            # Keep single-token labels (A, B, 1, 2, etc.) and stable ordering.
+            labels = [l for l in labels if len(l) <= 2]
+            if labels:
+                allowed = ", ".join(labels)
+        return f"""Solve the following problem. Think step by step. Use {ld} rules where the question involves code or APIs.
+Keep "reasoning" under ~1200 characters so the reply stays valid JSON (no huge unescaped strings).
+
+Question:
+\"\"\"{vt}\"\"\"
+{trunc_note}
+Options: {json.dumps(options) if options else "N/A"}
+
+{"Return ONLY one option label from: " + allowed + "." if (forced_type == "MCQ" and allowed) else ("Return ONLY the letter/number option label." if forced_type == "MCQ" else "Return exactly 'True' or 'False'.")}
+
+OUTPUT JSON:
+{{
+    "reasoning": "step-by-step logic...",
+    "final_answer": "..."
+}}"""
+
+    conceptual = contract.mode == "conceptual"
+    code_only_invalid = (
+        ""
+        if conceptual
+        else f"- The question requires code in {ld} but the claimed answer is only English with no real source.\n"
+    )
+    conceptual_note = (
+        "NOTE: The question asks for explanation or comparison — prose-only answers are valid. "
+        "Do not mark claimed_answer incorrect solely because it is not code.\n\n"
+        if conceptual
+        else ""
+    )
+    output_only = _verify_output_only_hint(vt)
+
+    return f"""You are verifying a practice problem ({ld} where relevant). First judge if the question is valid,
+then solve it if it is, and check whether the claimed answer is correct.
+Keep "reasoning" under ~2000 characters so the reply stays valid JSON.
+
+Question:
+\"\"\"{vt}\"\"\"
+{trunc_note}
+Claimed correct answer:
+\"\"\"{claimed_answer}\"\"\"
+
+{conceptual_note}{output_only}INVALID QUESTION — set claimed_answer_is_correct to false if ANY apply:
+- The question contains template/placeholder phrases (e.g. instructions meant for the author,
+  not the student), garbled code, or is incoherent.
+- The question does not ask for a clear programming task when it should (e.g. nonsense numbers
+  instead of code).
+- The claimed answer is not a plausible answer type for the question (e.g. a bare list of
+  decimals for a coding problem).
+- The claimed answer is a rubric or author note ("The correct answer should...", "The student should...",
+  "must be a function that...") instead of the actual code or model prose the student would submit.
+{code_only_invalid}
+STEPS (if the question is valid):
+1. Solve the question yourself. Show your reasoning.
+2. Compare your solution to the claimed answer.
+3. They do NOT need to be identical — just logically equivalent.
+   Ignore variable names, formatting, and minor syntax differences.
+   Only mark incorrect if the logic is fundamentally wrong.
+
+OUTPUT JSON:
+{{
+    "reasoning": "your solution and comparison...",
+    "final_answer": "your own answer to the question",
+    "claimed_answer_is_correct": true or false
+}}"""

--- a/backend/app/variant_gen/question_contract.py
+++ b/backend/app/variant_gen/question_contract.py
@@ -1,0 +1,453 @@
+"""
+Single place to decide *how* we treat an unseen question before generation.
+
+Today routing is mostly rule-based (keywords + light language detection), with an
+optional LLM assist:
+
+  1. Keep the QuestionContract field names stable (including ``question_format``).
+  2. ``QUESTION_ROUTER=llm`` — see ``question_router.route_stem``: one small JSON call
+     for ``question_format`` and ``language`` only; mode and reskin stay rule-derived.
+  3. Validators and prompts consume only QuestionContract — not scattered stems.
+
+Adding a new “kind” of question should mean: extend the contract (if needed),
+adjust one router, and add a narrow invariant — not new ad hoc branches
+throughout variant_gen.
+"""
+
+from __future__ import annotations
+
+import os
+import random
+import re
+from dataclasses import dataclass
+from pathlib import Path
+
+from dotenv import load_dotenv
+
+from .question_inputs import count_options, detect_format
+
+_SERVER_DIR = Path(__file__).resolve().parent.parent
+load_dotenv(_SERVER_DIR / ".env")
+load_dotenv()
+
+# ── Scenario domains (consumers: scenario_from_contract only) ────────
+THEMATIC_RESKINS = [
+    {
+        "theme": "Logistics & Shipping",
+        "swap_nouns": "packages, crates, shipments, pallets, delivery trucks, warehouses, weight limits",
+        "example": "Two Sum → find two packages whose weights add up to the truck's capacity",
+    },
+    {
+        "theme": "Finance & Banking",
+        "swap_nouns": "transactions, accounts, balances, transfers, interest rates, portfolios, deposits",
+        "example": "sum → calculate total deposits; search → find a fraudulent transaction",
+    },
+    {
+        "theme": "Healthcare & Patient Records",
+        "swap_nouns": "patients, doctors, appointments, medications, dosages, rooms, wait times",
+        "example": "priority queue → triage patients by severity; scheduling → assign time slots",
+    },
+    {
+        "theme": "Robotics & Automation",
+        "swap_nouns": "robots, sensors, waypoints, motor speeds, task queues, coordinates, battery levels",
+        "example": "graph → plan robot's path through waypoints; queue → process sensor readings in order",
+    },
+    {
+        "theme": "Social Network",
+        "swap_nouns": "users, friend lists, posts, likes, followers, messages, notifications",
+        "example": "graph → mutual friends; set operations → common followers between two users",
+    },
+    {
+        "theme": "Cybersecurity",
+        "swap_nouns": "login attempts, IP addresses, access logs, threat scores, firewall rules, permissions, tokens",
+        "example": "search → find suspicious IP; filtering → block IPs that exceed failed login threshold",
+    },
+    {
+        "theme": "E-Commerce",
+        "swap_nouns": "products, prices, stock counts, shopping carts, discounts, categories, customer orders",
+        "example": "filtering → remove out-of-stock items; sum → calculate cart total with discounts",
+    },
+    {
+        "theme": "Recipe & Cooking",
+        "swap_nouns": "ingredients, recipes, portions, cooking times, temperatures, pantry items",
+        "example": "sorting → sort recipes by prep time; linked list → chain of cooking steps",
+    },
+    {
+        "theme": "Music Playlist",
+        "swap_nouns": "songs, playlists, albums, artists, track durations, play counts, genres",
+        "example": "search → find a song in a shuffled playlist; sum → total playlist duration",
+    },
+    {
+        "theme": "Sports & Athletics",
+        "swap_nouns": "players, teams, scores, game rounds, standings, match results, rankings",
+        "example": "max/min → find the top scorer; recursion → tournament bracket elimination",
+    },
+    {
+        "theme": "Travel & Navigation",
+        "swap_nouns": "cities, routes, distances, flights, travel times, layovers, fuel costs",
+        "example": "graph traversal → find shortest route; DP → cheapest sequence of flights",
+    },
+    {
+        "theme": "File System & Documents",
+        "swap_nouns": "files, folders, file sizes, extensions, paths, permissions, timestamps",
+        "example": "tree traversal → list all files in nested folders; search → find a file by name",
+    },
+    {
+        "theme": "School & Grades",
+        "swap_nouns": "students, courses, grades, assignments, GPAs, semesters, classrooms",
+        "example": "dictionary → student grade lookup; sorting → rank students by GPA",
+    },
+    {
+        "theme": "Parking Lot",
+        "swap_nouns": "cars, parking spots, license plates, entry times, exit times, fees, levels",
+        "example": "stack → last car in first car out; search → find an open spot",
+    },
+]
+
+SWE_SCENARIOS = [
+    {
+        "domain": "Web API Development",
+        "context": "You are building a REST API backend.",
+        "entities": ["endpoints", "HTTP requests", "JSON responses", "users", "products", "orders"],
+    },
+    {
+        "domain": "DevOps & CI/CD",
+        "context": "You are maintaining a deployment pipeline.",
+        "entities": ["containers", "build stages", "deployment targets", "log entries", "service instances"],
+    },
+    {
+        "domain": "Chat Application",
+        "context": "You are developing a real-time messaging platform.",
+        "entities": ["messages", "channels", "users", "read receipts", "file attachments", "notifications"],
+    },
+    {
+        "domain": "Testing & QA",
+        "context": "You are building a test framework.",
+        "entities": ["test cases", "test suites", "mock objects", "coverage reports", "build outputs"],
+    },
+    {
+        "domain": "Package Manager / CLI Tool",
+        "context": "You are building a CLI tool that manages project dependencies.",
+        "entities": ["packages", "version constraints", "dependency trees", "lock files", "install targets"],
+    },
+]
+
+_CLASS_DESIGN_MARKERS = (
+    "write a class",
+    "class named",
+    "inherits",
+    "initializer",
+    "__init__",
+    "__str__",
+)
+
+# Substrings in lowercased text → treat as conceptual (no silly thematic reskin).
+_CONCEPTUAL_MARKERS = (
+    "describe ",
+    "explain ",
+    "what is the difference",
+    "difference between",
+    "what are the runtimes",
+    "name at least",
+    "how do they differ",
+    "why is",
+    "why ",
+    "what are",
+    "define ",
+)
+
+
+def _mentions_cpp_as_required_language(tl: str) -> bool:
+    """
+    True when the stem is actually about C++ coursework.
+
+    PDFs often say things like "no C++ component whatsoever" on otherwise pure C
+    questions — a naive `'c++' in text` substring match misroutes those to cpp.
+    """
+    if "c++" not in tl:
+        return False
+    for m in re.finditer(r"c\+\+", tl):
+        window = tl[max(0, m.start() - 20) : m.start()]
+        # "no C++ …" still contains the letters c++ — skip those hits.
+        if re.search(r"\b(no|not|without|instead of|avoid|never|isn't|isnt)\s*$", window):
+            continue
+        return True
+    return False
+
+
+def infer_programming_language(text: str) -> str:
+    """Guess language from raw exam text; validators and prompts follow this."""
+    o = os.getenv("QUESTION_LANG", "").strip().lower()
+    if o:
+        o = {"py": "python", "c++": "cpp", "cxx": "cpp", "cplusplus": "cpp"}.get(o, o)
+        if o in ("python", "cpp", "java", "generic"):
+            return o
+    tl = (text or "").lower()
+    t = text or ""
+    # Java / AP CS A: snippets often lack import/main; generics and keywords are the tell.
+    if (
+        re.search(r"\b(import\s+java|java\.util|public\s+static\s+void\s+main)\b", tl)
+        or "system.out" in tl
+        or "system.in" in tl
+        or re.search(r"\bpublic\s+(class|interface)\b", tl)
+        or re.search(r"\bimplements\b", tl)
+        or re.search(r"\b(class|interface)\s+\w+\s+extends\s+\w+", tl)
+        or re.search(
+            r"\b(arraylist|linkedlist|hashmap|hashset|treeset|priorityqueue|list|map|set|queue|stack)\s*<",
+            tl,
+        )
+        or " instanceof " in tl
+        or re.search(r"\bboolean\s+\w+", tl)
+        or "@override" in tl
+        or re.search(r"\b(private|protected)\s+(int|boolean|double|char)\s+\w+\s*;", t, re.I)
+        or re.search(r"\bString\s+[a-zA-Z_]\w*\s*[;=]", t)
+    ):
+        return "java"
+    # Stanford CS107-style C (vector + Vector* API). Not C++; prompts/validators use "generic".
+    if re.search(
+        r"\bVector(New|Append|Dispose|Delete|Insert|Replace|Split|Length|Nth)\s*\(",
+        t,
+    ) and "std::" not in t:
+        return "generic"
+    # C++ / intro-C course signals (keep broad: many PDFs lack #include in snippets)
+    if (
+        _mentions_cpp_as_required_language(tl)
+        or "cplusplus" in tl
+        or "std::" in t
+        or "#include" in t
+        or "namespace std" in tl
+        or "nullptr" in tl
+        or "static_cast" in tl
+        or "using namespace" in tl
+        or re.search(r"\bcout\b", tl)
+        or re.search(r"\bcin\b", tl)
+        or re.search(r"\bendl\b", tl)
+        or re.search(r"\bvector\s*<\s*\w+\s*>", t)
+        or re.search(r"\b(int|double|float|long|unsigned|char|bool|void)\s+\w+\s*=\s*[^;\n]+;", t)
+    ):
+        return "cpp"
+    if re.search(r"^\s*def\s+\w+", t, re.MULTILINE) or re.search(
+        r"\b(__init__|elif\s+|\bself\.|\bprint\s*\()\b", tl
+    ):
+        return "python"
+    if "python" in tl or "list method" in tl:
+        return "python"
+    return "python"
+
+
+def language_display(lang: str) -> str:
+    return {
+        "python": "Python",
+        "cpp": "C++",
+        "java": "Java",
+        "generic": "the same language as the original",
+    }[lang]
+
+
+def fence_lang(lang: str) -> str:
+    return {"python": "python", "cpp": "cpp", "java": "java", "generic": "text"}[lang]
+
+
+def question_mode(text: str) -> str:
+    """High-level routing: OOP exercise vs conceptual vs algorithmic word-problem reskin."""
+    t = (text or "").lower()
+    if any(kw in t for kw in _CLASS_DESIGN_MARKERS):
+        return "class_design"
+    if any(m in t for m in _CONCEPTUAL_MARKERS):
+        return "conceptual"
+    return "algorithmic"
+
+
+def looks_like_structural_trace_task(text: str) -> bool:
+    """
+    Generic signal: the student must produce intermediate structure or multi-step traces.
+
+    Used to turn off thematic reskin (parking lots, recipes, …) without naming specific
+    assignments or data structures — applies to heaps, trees, sorts, automata traces, etc.
+    """
+    t = (text or "").lower()
+    if any(
+        s in t
+        for s in (
+            "after each",
+            "following each",
+            "step-by-step",
+            "step by step",
+            "successive ",
+            "intermediate state",
+            "show the state",
+            "state after",
+            "draw the",
+            "illustrate each",
+            "trace the",
+            " record the state",
+        )
+    ):
+        return True
+    if "starting from" in t and any(
+        w in t
+        for w in (
+            "insert",
+            "delete",
+            "deletemin",
+            "delete min",
+            "remove",
+            "operation",
+            "performed",
+        )
+    ):
+        return True
+    if "after performing" in t and any(
+        w in t for w in ("operation", "insertion", "deletion", "step", "removal")
+    ):
+        return True
+    return False
+
+
+def looks_like_named_function_write_task(text: str) -> bool:
+    """
+    Specs that pin a function name/signature — reskinning tends to drift types and fail verify.
+
+    Kept generic (any PDF that says "write a function named …"), not tied to one course.
+    """
+    t = re.sub(r"\s+", " ", (text or "").lower())
+    return bool(
+        re.search(r"\bwrite\s+a\s+function\s+named\b", t)
+        or re.search(r"\bwrite\s+a\s+function\s+called\b", t)
+        or re.search(r"\bimplement\s+a\s+function\s+named\b", t)
+        or re.search(r"\bdefine\s+a\s+function\s+named\b", t)
+    )
+
+
+def _conceptual_cs_only_scenario() -> dict:
+    """Same theme block as conceptual mode — CS surface, no unrelated domains."""
+    return {
+        "style": "conceptual",
+        "theme": "Computer science course (same domain as the original)",
+        "swap_nouns": "(do not use — keep CS vocabulary from the original)",
+        "example": "Keep questions about sequences as questions about sequences; only tighten prose.",
+    }
+
+
+def expected_mcq_options_for_stem(text: str, question_format: str, language: str) -> int:
+    """
+    MCQ option count passed to ``is_invalid_variant``. 0 means do not enforce length
+    (C++ PDFs: numbered code lines look like A./1. options; ambiguous stems).
+    """
+    if question_format != "MCQ":
+        return 0
+    n = count_options(text)
+    if n < 2:
+        n = 4
+    if language == "cpp":
+        return 0
+    return n
+
+
+@dataclass
+class QuestionContract:
+    """Immutable-ish bundle of routing decisions for one source question."""
+
+    language: str
+    mode: str
+    allow_thematic_reskin: bool
+    question_format: str
+    expected_mcq_options: int
+    routing_source: str = "rules"
+
+
+def build_question_contract(text: str) -> QuestionContract:
+    """
+    Rule-based stem router (language, mode, reskin, MCQ vs FR vs TF).
+
+    For optional LLM assist on format/language only, use ``route_stem`` in
+    ``question_router.py`` (``QUESTION_ROUTER=llm``).
+    """
+    lang = infer_programming_language(text)
+    mode = question_mode(text)
+    allow = (
+        mode == "algorithmic"
+        and not looks_like_structural_trace_task(text)
+        and not looks_like_named_function_write_task(text)
+    )
+    qf = detect_format(text)
+    emcq = expected_mcq_options_for_stem(text, qf, lang)
+    return QuestionContract(
+        language=lang,
+        mode=mode,
+        allow_thematic_reskin=allow,
+        question_format=qf,
+        expected_mcq_options=emcq,
+        routing_source="rules",
+    )
+
+
+def scenario_from_contract(contract: QuestionContract) -> dict:
+    """Maps contract.mode → the scenario dict expected by _build_generation_prompt."""
+    if contract.mode == "class_design":
+        return {"style": "swe", **random.choice(SWE_SCENARIOS)}
+    if contract.mode == "conceptual":
+        return _conceptual_cs_only_scenario()
+    if not contract.allow_thematic_reskin:
+        # Algorithmic but trace-heavy, named-function spec, etc. — keep CS framing like conceptual.
+        return _conceptual_cs_only_scenario()
+    return {"style": "reskin", **random.choice(THEMATIC_RESKINS)}
+
+
+# ── CS vocabulary drift (conceptual FR only) ─────────────────────────
+
+_FR_CS_KEYWORDS = frozenset({
+    "python", "sequence", "sequences", "tuple", "tuples", "string", "strings",
+    "list", "lists", "dictionary", "dictionaries", "dict", "set", "sets",
+    "boolean", "booleans", "recursion", "recursive", "iterable", "iterables",
+    "mutable", "immutable", "immutability", "inheritance", "polymorphism",
+    "algorithm", "complexity", "array", "arrays", "stack", "stacks", "queue", "queues",
+    "tree", "trees", "graph", "graphs", "hash", "pointer", "heap",
+    "encapsulation", "namespace", "compiler", "interpreter", "garbage",
+})
+
+_FR_CS_SYNONYM_GROUPS = (
+    frozenset({
+        "sequence", "sequences", "tuple", "tuples", "string", "strings",
+        "list", "lists", "iterable", "iterables", "array", "arrays",
+    }),
+    frozenset({"dictionary", "dictionaries", "dict"}),
+    frozenset({"set", "sets"}),
+    frozenset({"recursion", "recursive"}),
+    frozenset({"boolean", "booleans"}),
+)
+
+_ALL_FR_CS_GROUP_TERMS = frozenset().union(*_FR_CS_SYNONYM_GROUPS)
+
+
+def _fr_cs_keywords_in_text(text: str) -> set:
+    tl = (text or "").lower()
+    return {k for k in _FR_CS_KEYWORDS if re.search(rf"\b{re.escape(k)}\b", tl)}
+
+
+def _fr_variant_covers_cs_terms(o_kw: set, v_kw: set) -> bool:
+    if o_kw & v_kw:
+        return True
+    for g in _FR_CS_SYNONYM_GROUPS:
+        if o_kw & g and not (v_kw & g):
+            return False
+    leftover = o_kw - _ALL_FR_CS_GROUP_TERMS
+    return not leftover or bool(leftover & v_kw)
+
+
+def free_response_cs_vocabulary_lost(original_text: str, variant: dict, contract: QuestionContract) -> bool:
+    """
+    True if variant should be rejected: conceptual question dropped CS terms
+    (e.g. sequences → parking lots). Verifier alone often misses this.
+    """
+    if contract.mode != "conceptual":
+        return False
+    o_kw = _fr_cs_keywords_in_text(original_text)
+    if not o_kw:
+        return False
+    blob = " ".join(
+        str(variant.get(k) or "")
+        for k in ("storyline", "task", "variant_text", "constraints")
+    )
+    v_kw = _fr_cs_keywords_in_text(blob)
+    return not _fr_variant_covers_cs_terms(o_kw, v_kw)

--- a/backend/app/variant_gen/question_inputs.py
+++ b/backend/app/variant_gen/question_inputs.py
@@ -1,0 +1,158 @@
+"""Classify raw exam text: skip rules, vision, format, coarse algorithm tag."""
+
+import re
+from typing import Any, Dict
+
+from .config import _ALGORITHM_PATTERNS, openrouter_vision_enabled
+
+
+def extract_algorithm(text: str) -> str:
+    t = text.lower()
+    matches = []
+    for algo_name, keywords in _ALGORITHM_PATTERNS:
+        score = sum(1 for kw in keywords if kw in t)
+        if score > 0:
+            matches.append((algo_name, score))
+    if not matches:
+        return "general problem solving"
+    matches.sort(key=lambda x: x[1], reverse=True)
+    return matches[0][0]
+
+
+def should_skip_question(text: str) -> bool:
+    t = text.lower()
+    junk_triggers = [
+        "honor code",
+        "academic integrity",
+        "policies",
+        "adhere to",
+        "judicial board",
+        "leaving this question blank",
+        "docstrings",
+        "merely examples",
+        "by selecting",
+        "agree that",
+    ]
+    return any(trigger in t for trigger in junk_triggers)
+
+
+def _is_code_or_written_answer_question(text: str) -> bool:
+    t = text.lower()
+    return any(
+        p in t
+        for p in (
+            "write a function",
+            "write a class",
+            "write pseudocode",
+            "recursive function",
+            "def ",
+            "__init__",
+            "class named",
+            "inherits",
+        )
+    )
+
+
+def should_use_vision(q_data: Dict[str, Any]) -> bool:
+    if not openrouter_vision_enabled():
+        return False
+
+    text = q_data.get("text", "")
+    images = q_data.get("image_crops", [])
+    if not images:
+        return False
+
+    if _is_code_or_written_answer_question(text):
+        return False
+
+    vision_keywords = [
+        "shown",
+        "diagram",
+        "figure",
+        "graph",
+        "tree",
+        "circuit",
+        "table",
+        "plot",
+        "chart",
+    ]
+    for k in vision_keywords:
+        if k in text.lower():
+            return True
+
+    has_mcq = re.search(r"(\b[A-E1-5][\.\)]\s)|(\([a-e]\))", text)
+    is_tf = "true" in text.lower() and "false" in text.lower()
+
+    if (has_mcq or is_tf) and len(text) > 30:
+        return False
+    if len(text) > 60:
+        return False
+
+    return True
+
+
+def _looks_like_numbered_written_subproblems(text: str) -> bool:
+    """Multi-part exam prompts use '1. Foo 2. Bar' like MCQ option lines — treat as written, not MCQ."""
+    t = (text or "").lower()
+    numbered = len(re.findall(r"(?:^|\n)\s*\d+\.\s+\S", text or ""))
+    if numbered < 2:
+        return False
+    if "for each of the following" in t:
+        return True
+    if ("worst-case runtime" in t or "worst case runtime" in t) and (
+        "explanation" in t or "brief" in t or "sentence" in t
+    ):
+        return True
+    if "give a" in t and "runtime" in t and ("explanation" in t or "brief" in t):
+        return True
+    return False
+
+
+def detect_format(text: str) -> str:
+    text_lower = text.lower()
+    if "true" in text_lower and "false" in text_lower:
+        if len(text) < 200 or "select" in text_lower:
+            return "TRUE_FALSE"
+    # Coding / written tasks often include numbered lines or lettered bullets; classify before MCQ heuristics.
+    if re.search(
+        r"\b(?:write\s+pseudocode|write\s+a\s+(?:function|class|method)|recursive\s+function)\b",
+        text_lower,
+    ):
+        return "FREE_RESPONSE"
+    has_mcq = re.search(r"(?:^|\n|\s)(?:[A-E]|[1-5])[\.\)]\s+\w+", text)
+    if has_mcq and _looks_like_numbered_written_subproblems(text):
+        return "FREE_RESPONSE"
+    if has_mcq:
+        return "MCQ"
+    # Scanned exams: "o  A   option text" or letter on its own line without \w+ immediately after
+    letter_marks = len(re.findall(r"(?:^|\n|\s)[A-E][\.\)]\s*", text, flags=re.IGNORECASE))
+    # "o  A   option" (circle / scan noise; letter not always followed by .)
+    o_letter_opts = len(re.findall(r"(?:^|\n|\s)o\s+([A-E])\b", text, flags=re.IGNORECASE))
+    # AP / textbook style "(a)  I only" through "(e)  ..." — not matched by bare "A." above.
+    paren_letter_opts = len(re.findall(r"(?:^|\n|\s)\(\s*([A-E])\s*\)", text, flags=re.IGNORECASE))
+    mcq_phrases = (
+        "which of the following",
+        "which of these",
+        "which one of the following",
+        "select all",
+        "choose the",
+        "all of the following are",
+    )
+    if (
+        letter_marks >= 2 or o_letter_opts >= 2 or paren_letter_opts >= 2
+    ) and any(k in text_lower for k in mcq_phrases):
+        return "MCQ"
+    return "FREE_RESPONSE"
+
+
+def count_options(text: str) -> int:
+    # Only treat explicit "A)" / "A." / "1)" / "1." patterns as options.
+    # Tree/traversal dumps can look like dozens of fake options — cap and bail to 0.
+    letter_opts = re.findall(r"(?:^|\n)\s*[A-E][\.\)]\s+\S", text)
+    num_opts = re.findall(r"(?:^|\n)\s*[1-5][\.\)]\s+\S", text)
+    count = max(len(letter_opts), len(num_opts))
+    if count < 2:
+        return 0
+    if count > 10:
+        return 0
+    return count

--- a/backend/app/variant_gen/question_router.py
+++ b/backend/app/variant_gen/question_router.py
@@ -1,0 +1,161 @@
+"""
+Stem routing: one entry point for format + QuestionContract.
+
+``QUESTION_ROUTER=rules`` (default): same behavior as ``build_question_contract`` — all fields
+from heuristics.
+
+``QUESTION_ROUTER=llm``: one small JSON call classifies ``question_format`` and ``language`` only;
+``mode`` and ``allow_thematic_reskin`` stay rule-derived (stable prompts / reskin safety). On LLM
+failure, falls back to full rules and ``routing_source=rules``.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any, Optional
+
+from .config import (
+    generation_source_max_chars,
+    question_router_name,
+    question_router_timeout_sec,
+    resolved_question_router_model,
+)
+from .llm_client import call_llm
+from .question_contract import (
+    QuestionContract,
+    build_question_contract,
+    expected_mcq_options_for_stem,
+)
+
+_ALLOWED_FORMATS = frozenset({"MCQ", "FREE_RESPONSE", "TRUE_FALSE"})
+_ALLOWED_LANGS = frozenset({"python", "cpp", "java", "generic"})
+
+
+def _clip_stem(text: str, limit: int) -> str:
+    t = text or ""
+    if len(t) <= limit:
+        return t
+    head = (limit * 2) // 3
+    tail = limit - head - 80
+    if tail < 800:
+        tail = 800
+        head = max(400, limit - tail - 80)
+    return t[:head] + "\n\n[... truncated ...]\n\n" + t[-tail:]
+
+
+def _normalize_format(val: Any) -> Optional[str]:
+    if val is None:
+        return None
+    s = str(val).strip().upper().replace(" ", "_").replace("-", "_")
+    aliases = {
+        "MULTIPLE_CHOICE": "MCQ",
+        "MULTIPLECHOICE": "MCQ",
+        "CHOICE": "MCQ",
+        "FREE_RESPONSE": "FREE_RESPONSE",
+        "FREERESPONSE": "FREE_RESPONSE",
+        "FR": "FREE_RESPONSE",
+        "FREE": "FREE_RESPONSE",
+        "TRUE_FALSE": "TRUE_FALSE",
+        "TRUEFALSE": "TRUE_FALSE",
+        "T_F": "TRUE_FALSE",
+        "TF": "TRUE_FALSE",
+    }
+    s = aliases.get(s, s)
+    return s if s in _ALLOWED_FORMATS else None
+
+
+def _normalize_lang(val: Any) -> Optional[str]:
+    if val is None:
+        return None
+    s = str(val).strip().lower()
+    s = {"py": "python", "c++": "cpp", "cplusplus": "cpp", "cxx": "cpp"}.get(s, s)
+    return s if s in _ALLOWED_LANGS else None
+
+
+def _llm_router_prompt(stem: str) -> str:
+    return (
+        "You classify an exam question stem for an automated variant generator.\n"
+        "Return ONLY one JSON object (no markdown) with exactly these keys:\n"
+        '  "question_format": one of MCQ, FREE_RESPONSE, TRUE_FALSE\n'
+        '  "language": one of python, cpp, java, generic\n'
+        "Rules:\n"
+        "- MCQ: student picks labeled options (A–E, 1–5, or (a)–(e)), including Roman-numeral clauses "
+        "with lettered answer choices.\n"
+        "- TRUE_FALSE: explicit true/false style.\n"
+        "- FREE_RESPONSE: written answer, traces, code to write, proofs, etc.\n"
+        "- generic: stem is clearly C, Scheme, mixed course-specific code, or language is ambiguous; "
+        "do not default to python unless the stem is actually Python.\n"
+        "- java: AP-style or explicit Java syntax (class/interface, public static void, etc.).\n"
+        "- cpp: C++ is the tested language (classes, std::, etc.); not for stems that only say "
+        '"no C++" or are pure C with a C API.\n'
+        "Stem:\n---\n"
+        f"{stem}\n---\n"
+    )
+
+
+def _try_llm_route_stem(text: str) -> Optional[QuestionContract]:
+    """LLM supplies format + language; mode and reskin from rules."""
+    base = build_question_contract(text)
+    stem = _clip_stem(text, generation_source_max_chars())
+    prompt = _llm_router_prompt(stem)
+    model = resolved_question_router_model()
+    timeout = question_router_timeout_sec()
+    raw = call_llm(prompt, image_paths=None, temperature=0.0, model=model, timeout_sec=timeout)
+    if not raw or not isinstance(raw, dict):
+        return None
+    fmt = _normalize_format(raw.get("question_format"))
+    lang = _normalize_lang(raw.get("language"))
+    if fmt is None or lang is None:
+        return None
+    return QuestionContract(
+        language=lang,
+        mode=base.mode,
+        allow_thematic_reskin=base.allow_thematic_reskin,
+        question_format=fmt,
+        expected_mcq_options=expected_mcq_options_for_stem(text, fmt, lang),
+        routing_source="llm",
+    )
+
+
+def route_stem(text: str) -> QuestionContract:
+    """
+    Single entry point for ``question_format`` + contract fields.
+
+    Env:
+        QUESTION_ROUTER — ``rules`` (default) or ``llm``
+        QUESTION_ROUTER_MODEL — optional OpenRouter slug (defaults to OPENROUTER_MODEL)
+        QUESTION_ROUTER_TIMEOUT — HTTP read timeout seconds (default 25)
+    """
+    name = question_router_name()
+    if name != "llm":
+        return build_question_contract(text)
+    merged = _try_llm_route_stem(text)
+    if merged is not None:
+        return merged
+    print("  Question router: LLM route failed or invalid JSON; using rules.")
+    return build_question_contract(text)
+
+
+def telemetry_routing_line(question_id: str, contract: QuestionContract) -> str:
+    """One JSON line for log aggregation (stderr or grep)."""
+    payload = {
+        "event": "stem_routed",
+        "question_id": question_id,
+        "routing_source": contract.routing_source,
+        "question_format": contract.question_format,
+        "language": contract.language,
+        "mode": contract.mode,
+        "allow_thematic_reskin": contract.allow_thematic_reskin,
+    }
+    return f"[variant_gen:telemetry] {json.dumps(payload, ensure_ascii=False)}"
+
+
+def telemetry_outcome_line(question_id: str, outcome: str, detail: str = "") -> str:
+    """Outcome after all retries (success not emitted here — batch runner already logs)."""
+    payload = {
+        "event": "variant_outcome",
+        "question_id": question_id,
+        "outcome": outcome,
+        "detail": (detail or "")[:500],
+    }
+    return f"[variant_gen:telemetry] {json.dumps(payload, ensure_ascii=False)}"

--- a/backend/app/variant_gen/tests/__init__.py
+++ b/backend/app/variant_gen/tests/__init__.py
@@ -1,0 +1,1 @@
+# Tests for variant_gen (run from server/: python -m unittest variant_gen.tests.test_stem_routing -v)

--- a/backend/app/variant_gen/tests/test_stem_routing.py
+++ b/backend/app/variant_gen/tests/test_stem_routing.py
@@ -1,0 +1,59 @@
+"""Golden checks for rule-based stem routing (no OpenRouter calls)."""
+
+import unittest
+
+
+class TestStemRoutingRules(unittest.TestCase):
+    def test_ap_style_paren_mcq(self):
+        from variant_gen.question_router import route_stem
+
+        stem = """Which of the following satisfies the interface?
+public class Circle implements Shape { }
+  I.  public int foo(Shape x)
+ II.  public int foo(Circle x)
+(a)  I only
+(b)  II only
+(c)  I and II
+(d)  None
+(e)  All
+"""
+        c = route_stem(stem)
+        self.assertEqual(c.question_format, "MCQ")
+        self.assertEqual(c.routing_source, "rules")
+        self.assertEqual(c.language, "java")
+        self.assertGreaterEqual(c.expected_mcq_options, 2)
+
+    def test_cs107_negated_cpp_is_generic(self):
+        from variant_gen.question_router import route_stem
+
+        stem = """Problem 1: Matchmaking
+Write a function generateAllCouples that returns a new vector.
+No C++ component whatsoever. It's all C.
+VectorNew(&boys, sizeof(char *), StringFree, 0);
+vector generateAllCouples(vector *boys, vector *girls) {
+  vector couples;
+"""
+        c = route_stem(stem)
+        self.assertEqual(c.language, "generic")
+        self.assertEqual(c.routing_source, "rules")
+
+    def test_write_function_defaults_fr_not_mcq_numbered_noise(self):
+        from variant_gen.question_router import route_stem
+
+        stem = """Write a function longestPrefix that takes two lists of strings.
+1. First consider empty lists.
+2. Then scan characters left to right.
+"""
+        c = route_stem(stem)
+        self.assertEqual(c.question_format, "FREE_RESPONSE")
+
+    def test_contract_has_question_format(self):
+        from variant_gen.question_contract import build_question_contract
+
+        c = build_question_contract("Which is true? (a) foo (b) bar")
+        self.assertTrue(hasattr(c, "question_format"))
+        self.assertEqual(c.routing_source, "rules")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/backend/app/variant_gen/variant_validation.py
+++ b/backend/app/variant_gen/variant_validation.py
@@ -1,0 +1,315 @@
+"""Deterministic checks on model JSON: placeholders, MCQ shape, similarity."""
+
+import re
+from difflib import SequenceMatcher
+from typing import Any, Dict, Optional, Tuple
+
+from .config import DEBUG, SIMILARITY_THRESHOLD, SIMILARITY_THRESHOLD_EXPLANATION
+from .policies import get_policy
+from .question_contract import (
+    QuestionContract,
+    fence_lang,
+    free_response_cs_vocabulary_lost,
+    language_display,
+)
+
+
+def similarity_threshold_for_original(original_text: str) -> float:
+    t = (original_text or "").lower()
+    if any(
+        k in t
+        for k in (
+            "explain ",
+            "why is it",
+            "why is ",
+            "important to ",
+            "difference between",
+            "what is the difference",
+            "name at least",
+            "how do they differ",
+        )
+    ):
+        return SIMILARITY_THRESHOLD_EXPLANATION
+    return SIMILARITY_THRESHOLD
+
+
+def is_too_similar(original_text: str, variant_text: str) -> bool:
+    thresh = similarity_threshold_for_original(original_text)
+    ratio = SequenceMatcher(None, original_text.lower(), variant_text.lower()).ratio()
+    if DEBUG:
+        print(f"[DEBUG] Similarity ratio: {ratio:.2f} (threshold {thresh:.2f})")
+    return ratio > thresh
+
+
+_BAD_PLACEHOLDER_FRAGMENTS = (
+    "1-2 sentence real-world scenario",
+    "the full problem statement combining",
+    "the clear problem definition",
+    "any constraints or rules carried over",
+    "the complete correct answer",
+)
+
+_META_ANSWER_SNIPPETS = (
+    "the correct answer should",
+    "the student should",
+    "your answer should be",
+    "acceptable responses",
+    "grading rubric",
+    "must be a function definition that",
+    "solution should use",
+)
+
+
+def original_asks_for_code_submission(original_text: Optional[str]) -> bool:
+    t = (original_text or "").lower()
+    return any(
+        p in t
+        for p in (
+            "write a function",
+            "write a class",
+            "write pseudocode",
+            "recursive function",
+            "implement a function",
+            "define a function",
+            "complete the following program",
+            "complete the following code",
+            "write the following function",
+            "implement the following",
+        )
+    )
+
+
+def _variant_asks_for_code_submission(variant: Dict[str, Any]) -> bool:
+    """True if the *variant* text asks the student to submit code (any language)."""
+    blob = " ".join(
+        str(variant.get(k) or "")
+        for k in ("variant_text", "task", "constraints")
+    ).lower()
+    return any(
+        p in blob
+        for p in (
+            "write a function",
+            "write a class",
+            "write pseudocode",
+            "recursive function",
+            "implement a function",
+            "define a function",
+        )
+    )
+
+
+def normalize_answer(ans: Any) -> str:
+    s = str(ans).strip().upper()
+    if s in ["TRUE", "T", "YES"]:
+        return "TRUE"
+    if s in ["FALSE", "F", "NO"]:
+        return "FALSE"
+    # Accept any single-letter option label, not just A–E.
+    match = re.search(r"(?:^|\s|\.|^OPTION\s)([A-Z1-5])(?:$|\s|\.|[\)])", s)
+    if match:
+        val = match.group(1)
+    else:
+        # e.g. "The answer is (B)" or trailing letter after junk / numeric distractors
+        m2 = re.search(r"\b([A-Z])\b", s)
+        val = m2.group(1) if m2 else s[:1]
+
+    mapping = {"1": "A", "2": "B", "3": "C", "4": "D", "5": "E"}
+    return mapping.get(val, val)
+
+
+def mcq_correct_option_label(correct_answer: Any, options: Any) -> Tuple[Optional[str], Optional[str]]:
+    if not options or not isinstance(options, dict):
+        return None, None
+    ca = str(correct_answer).strip()
+    candidates = {ca, normalize_answer(ca)}
+    m = re.match(r"^([A-Z])", ca, re.I)
+    if m:
+        L = m.group(1).upper()
+        candidates.add(L)
+        # Only add numeric mapping for the canonical A–E range.
+        if "A" <= L <= "E":
+            candidates.add(str(ord(L) - ord("A") + 1))
+    m = re.match(r"^([1-5])", ca)
+    if m:
+        num = m.group(1)
+        candidates.add(num)
+        candidates.add(chr(ord("A") + int(num) - 1))
+    na = normalize_answer(ca)
+    if na in ("A", "B", "C", "D", "E"):
+        candidates.add(str(ord(na) - ord("A") + 1))
+    for k in candidates:
+        if k and k in options:
+            return k, str(options[k]).strip().lower()
+    return None, None
+
+
+def _answer_looks_like_code(ca: str, lang: str) -> bool:
+    s = ca or ""
+    sl = s.lower()
+    if lang == "python":
+        return "def " in s or "class " in sl
+    if lang == "cpp":
+        return bool(
+            re.search(r"\b(class|struct|void|int|bool)\b", sl)
+            and ("{" in s or ";" in s)
+        ) or "#include" in s
+    if lang == "java":
+        return "class " in sl or re.search(r"\b(public|private)\s+.*\(", s) is not None
+    return bool(re.search(r"def\s+\w+|class\s+\w+", sl) or ("{" in s and ";" in s))
+
+
+def _line_looks_like_code_definition(line: str, lang: str) -> bool:
+    if lang == "python":
+        return bool(re.search(r"^\s*(def|class)\s+\w", line))
+    if lang in ("cpp", "java", "generic"):
+        if re.search(r"^\s*(class|struct|template|namespace)\b", line):
+            return True
+        if lang == "java" and re.search(r"^\s*(public|private|protected)\s+(\w+\s+)*\w+\s+\w+\s*\(", line):
+            return True
+        if re.search(
+            r"^\s*(inline\s+)?(static\s+)?(void|bool|int|long|double|float|char|auto|string|unsigned)\b.+\([^)]*\)",
+            line,
+        ):
+            return True
+        if re.search(r"^\s*[\w:<>,\s&*]+\s+\w+\s*\([^)]*\)\s*\{?\s*$", line):
+            return True
+    return bool(re.search(r"^\s*(def|class)\s+\w", line))
+
+
+def _variant_code_blob_heuristic(variant_text: str, lang: str) -> bool:
+    vt = variant_text or ""
+    if vt.count("```") >= 2:
+        return False
+    if vt.count("\n") >= 6:
+        return False
+    lines = vt.splitlines()
+    has_code_line = any(_line_looks_like_code_definition(l, lang) for l in lines)
+    if not has_code_line:
+        return False
+    if len(vt) > 480 and vt.count("\n") < 4:
+        return True
+    for line in lines:
+        if _line_looks_like_code_definition(line, lang) and len(line) > 160:
+            return True
+    return False
+
+
+def free_response_correct_answer_invalid(
+    correct_answer: Any,
+    variant: Dict[str, Any],
+    lang: str,
+    contract: QuestionContract,
+    original_text: Optional[str],
+) -> Optional[str]:
+    if correct_answer is None:
+        ca = ""
+    elif isinstance(correct_answer, str):
+        ca = correct_answer.strip()
+    else:
+        ca = str(correct_answer).strip()
+    if not ca:
+        return "empty correct_answer"
+    ca_lower = ca.lower()
+    for frag in _META_ANSWER_SNIPPETS:
+        if frag in ca_lower:
+            return "correct_answer is meta/rubric, not a concrete solution"
+
+    # Only treat as "must submit code" if the *source* asked for it. Reskins often
+    # add "write a function…" even for trace-the-output / fill-in questions.
+    require_code = _variant_asks_for_code_submission(variant) and original_asks_for_code_submission(
+        original_text or ""
+    )
+
+    if require_code:
+        if not _answer_looks_like_code(ca, lang):
+            return f"coding task requires correct_answer with real {language_display(lang)} code"
+
+    return None
+
+
+def autofix_list_method_mcq(variant: Dict[str, Any], original_text: str, lang: str) -> bool:
+    if lang != "python":
+        return False
+    pol = get_policy("python")
+    return pol.list_method_mcq_autofix(
+        variant,
+        original_text,
+        normalize_answer=normalize_answer,
+        mcq_correct_option_label=mcq_correct_option_label,
+    )
+
+
+def is_invalid_variant(
+    variant: Dict[str, Any],
+    forced_type: str,
+    expected_mcq_options: int,
+    original_text: str,
+    contract: QuestionContract,
+) -> Optional[str]:
+    lang = contract.language
+    vt_raw = (variant.get("variant_text") or "").strip()
+    vt = vt_raw.lower()
+    if len(vt) < 40:
+        return "variant_text too short"
+
+    for frag in _BAD_PLACEHOLDER_FRAGMENTS:
+        if frag in vt:
+            return f"placeholder text in variant_text: {frag[:40]}"
+
+    for field in ("storyline", "task"):
+        val = (variant.get(field) or "").strip().lower()
+        for frag in _BAD_PLACEHOLDER_FRAGMENTS:
+            if frag in val:
+                return f"placeholder in {field}"
+
+    ca = variant.get("correct_answer")
+    if isinstance(ca, (list, dict)):
+        return "correct_answer is not a string"
+    if ca is None:
+        ca = ""
+
+    if forced_type == "FREE_RESPONSE":
+        fr_err = free_response_correct_answer_invalid(
+            ca, variant, lang, contract, original_text
+        )
+        if fr_err:
+            return fr_err
+        if free_response_cs_vocabulary_lost(original_text, variant, contract):
+            return "conceptual FR drifted off-topic (keep CS terms from the original, not a novelty theme)"
+        ca_str = ca if isinstance(ca, str) else str(ca)
+        if _variant_code_blob_heuristic(vt_raw, lang):
+            return (
+                f"code in variant_text is crammed (use fenced ```{fence_lang(lang)} ``` blocks and line breaks)"
+            )
+        if lang == "python":
+            pol = get_policy("python")
+            if pol and not pol.answer_parseable(ca_str):
+                return "correct_answer has invalid Python syntax"
+            if pol and pol.answer_has_mutable_defaults(ca_str) and not pol.original_shows_mutable_defaults(original_text):
+                return "correct_answer uses mutable default [] or {}; use None unless original does"
+
+    if forced_type == "MCQ":
+        opts = variant.get("options")
+        if not opts or not isinstance(opts, dict):
+            return "MCQ missing or invalid options"
+        n = len(opts)
+        if expected_mcq_options >= 2 and n != expected_mcq_options:
+            return f"expected {expected_mcq_options} MCQ options, got {n}"
+        vals = [str(v).strip() for v in opts.values()]
+        # Avoid false positives on legitimate numeric MCQs (decimals, measurements).
+        if (
+            vals
+            and len(vals) >= 4
+            and all(re.match(r"^0\.\d+$", v) for v in vals if v)
+            and not any(re.search(r"[a-zA-Z]", v) for v in vals if v)
+        ):
+            return "MCQ options look like garbage probabilities"
+
+        if lang == "python":
+            pol = get_policy("python")
+            if pol:
+                err = pol.validate_list_method_mcq(variant, original_text, vt, mcq_correct_option_label)
+                if err:
+                    return err
+
+    return None

--- a/backend/tests/test_variant_endpoint_helpers.py
+++ b/backend/tests/test_variant_endpoint_helpers.py
@@ -1,0 +1,58 @@
+import pathlib
+import sys
+import unittest
+from unittest.mock import patch
+
+sys.path.insert(0, str(pathlib.Path(__file__).resolve().parents[1]))
+
+from app.main import _save_variant_draft_question
+from app.models import Question
+
+
+class VariantEndpointHelperTests(unittest.TestCase):
+    def test_saved_variant_draft_copies_source_blooms_taxonomy(self):
+        source = Question(
+            id=9,
+            qid="Q00000009",
+            title="Trace recursion",
+            text="Write a recursive function.",
+            tags="recursion",
+            keywords="python",
+            school="UCSB",
+            user_school="UCSB",
+            course="CS 8",
+            course_type="Intro CS",
+            question_type="fr",
+            blooms_taxonomy="Apply",
+            answer_choices="[]",
+            user_id="teacher-1",
+        )
+        variant = {
+            "type": "FREE_RESPONSE",
+            "question": "Write a recursive function named largest_score.",
+            "answer": "def largest_score(scores): return max(scores)",
+            "language": "python",
+            "algorithm": "recursion",
+            "scenario_domain": "Sports",
+        }
+
+        with patch("app.main.create_question") as create_question:
+            _save_variant_draft_question(
+                session=object(),
+                source_question=source,
+                variant=variant,
+                user_id="teacher-1",
+                run_source="variant:Q00000009:test",
+                run_tag="variant-source:Q00000009",
+                number=1,
+            )
+
+        kwargs = create_question.call_args.kwargs
+        self.assertEqual(kwargs["blooms_taxonomy"], "Apply")
+        self.assertFalse(kwargs["is_verified"])
+        self.assertEqual(kwargs["question_type"], "fr")
+        self.assertIsNone(kwargs["source_pdf"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/backend/tests/test_variant_gen_adapter.py
+++ b/backend/tests/test_variant_gen_adapter.py
@@ -1,0 +1,108 @@
+import json
+import pathlib
+import sys
+import unittest
+
+sys.path.insert(0, str(pathlib.Path(__file__).resolve().parents[1]))
+
+from app.models import Question
+from app.variant_gen.milestone_one_adapter import (
+    question_to_variant_gen_db,
+    question_to_variant_gen_question,
+    source_text_for_variant_generation,
+)
+
+
+class VariantGenAdapterTests(unittest.TestCase):
+    def test_mcq_choices_are_appended_when_stored_separately(self):
+        question = Question(
+            id=42,
+            qid="Q00000042",
+            title="List method",
+            text="Which Python list method adds one item to the end of a list?",
+            question_type="mcq",
+            answer_choices=json.dumps(["append", "extend", "pop", "sort"]),
+            correct_answer="append",
+            user_id="teacher-1",
+            course="CS 8",
+            blooms_taxonomy="Apply",
+        )
+
+        adapted = question_to_variant_gen_question(question)
+
+        self.assertEqual(adapted["question_id"], "caliber_Q00000042")
+        self.assertIn("Options:", adapted["text"])
+        self.assertIn("A. append", adapted["text"])
+        self.assertIn("D. sort", adapted["text"])
+        self.assertEqual(adapted["image_crops"], [])
+        self.assertEqual(adapted["metadata"]["caliber_id"], 42)
+        self.assertEqual(adapted["metadata"]["course"], "CS 8")
+        self.assertEqual(adapted["metadata"]["blooms_taxonomy"], "Apply")
+
+    def test_existing_labeled_options_are_not_duplicated(self):
+        question = Question(
+            qid="Q00000002",
+            text="Which is correct?\nA. One\nB. Two\nC. Three\nD. Four",
+            question_type="mcq",
+            answer_choices=json.dumps(["One", "Two", "Three", "Four"]),
+            correct_answer="A",
+            user_id="teacher-1",
+        )
+
+        text = source_text_for_variant_generation(question)
+
+        self.assertEqual(text.count("A. One"), 1)
+        self.assertNotIn("Options:", text)
+
+    def test_true_false_text_gets_format_hint(self):
+        question = Question(
+            qid="Q00000003",
+            text="Python lists are mutable.",
+            question_type="true_false",
+            answer_choices="[]",
+            correct_answer="True",
+            user_id="teacher-1",
+        )
+
+        text = source_text_for_variant_generation(question)
+
+        self.assertIn("Answer True or False.", text)
+
+    def test_free_response_keeps_rubric_choices_out_of_stem(self):
+        rubric = [{"part_label": "A", "points": 2, "rubric_text": "Mentions base case"}]
+        question = Question(
+            qid="Q00000004",
+            text="Explain why recursion needs a base case.",
+            question_type="fr",
+            answer_choices=json.dumps(rubric),
+            correct_answer="",
+            user_id="teacher-1",
+        )
+
+        text = source_text_for_variant_generation(question)
+
+        self.assertEqual(text, "Explain why recursion needs a base case.")
+        self.assertNotIn("Mentions base case", text)
+
+    def test_question_wraps_in_one_ingestion_db_shape(self):
+        question = Question(
+            id=7,
+            qid="Q00000007",
+            text="Write a function named double that returns x * 2.",
+            question_type="fr",
+            answer_choices="[]",
+            user_id="teacher-1",
+            source_pdf="practice.pdf",
+        )
+
+        db = question_to_variant_gen_db(question)
+
+        self.assertEqual(db["schema_version"], "1.0")
+        self.assertEqual(len(db["ingestions"]), 1)
+        self.assertEqual(db["ingestions"][0]["ingestion_id"], "ing_caliber_Q00000007")
+        self.assertEqual(db["ingestions"][0]["source_pdf"], "practice.pdf")
+        self.assertEqual(len(db["ingestions"][0]["questions"]), 1)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/frontend/src/api.js
+++ b/frontend/src/api.js
@@ -396,6 +396,41 @@ export async function getQuestions(filters = {}) {
 }
 
 /**
+ * Fetch the current user's draft questions.
+ */
+export async function getDraftQuestions(filters = {}) {
+  try {
+    const headers = await getAuthHeaders();
+
+    const params = new URLSearchParams();
+    if (filters.skip !== undefined) params.append('skip', String(filters.skip));
+    if (filters.limit !== undefined) params.append('limit', String(filters.limit));
+
+    const url = `${API_BASE}/api/questions/drafts${params.toString() ? `?${params.toString()}` : ''}`;
+    const response = await apiFetch(url, { headers });
+
+    if (!response.ok) {
+      const errorText = await response.text();
+      let errorMessage = 'Failed to fetch draft questions';
+      try {
+        const errorJson = JSON.parse(errorText);
+        errorMessage = errorJson.detail || errorMessage;
+      } catch (e) {
+        errorMessage = errorText || errorMessage;
+      }
+      throw new Error(errorMessage);
+    }
+
+    return response.json();
+  } catch (error) {
+    if (error.message === 'Failed to fetch' || error.message.includes('fetch')) {
+      throw new Error('Cannot connect to backend. Make sure the backend server is running on http://localhost:8000');
+    }
+    throw error;
+  }
+}
+
+/**
  * Fetch all questions from all users
  */
 export async function getAllQuestions(filters = {}) {
@@ -447,6 +482,46 @@ export async function getQuestion(id) {
   }
 
   return await response.json();
+}
+
+/**
+ * Generate an unverified draft variant from an existing question.
+ */
+export async function generateQuestionVariant(questionId, count = 1) {
+  try {
+    const headers = await getAuthHeaders();
+    const params = new URLSearchParams();
+    if (count !== undefined && count !== null) {
+      params.append('count', String(count));
+    }
+
+    const response = await apiFetch(
+      `${API_BASE}/api/questions/${questionId}/variants${params.toString() ? `?${params.toString()}` : ''}`,
+      {
+        method: 'POST',
+        headers,
+      }
+    );
+
+    if (!response.ok) {
+      const errorText = await response.text();
+      let errorMessage = 'Failed to generate variant';
+      try {
+        const errorJson = JSON.parse(errorText);
+        errorMessage = errorJson.detail || errorMessage;
+      } catch (e) {
+        errorMessage = errorText || errorMessage;
+      }
+      throw new Error(errorMessage);
+    }
+
+    return response.json();
+  } catch (error) {
+    if (error.message === 'Failed to fetch' || error.message.includes('fetch')) {
+      throw new Error('Cannot connect to backend. Make sure the backend server is running on http://localhost:8000');
+    }
+    throw error;
+  }
 }
 
 /**

--- a/frontend/src/components/CollapsibleSection.jsx
+++ b/frontend/src/components/CollapsibleSection.jsx
@@ -15,6 +15,7 @@ import React, { useState, useEffect } from 'react';
  * @param {Object} user - Current user object (for permissions)
  * @param {boolean} isTeacher - Whether current user is a teacher
  * @param {React.ReactNode} emptyStateContent - Content to show when no questions exist
+ * @param {React.ReactNode} headerContent - Optional content rendered under the title
  */
 export default function CollapsibleSection({ 
   title, 
@@ -28,7 +29,8 @@ export default function CollapsibleSection({
   renderQuestionCard,
   user,
   isTeacher,
-  emptyStateContent
+  emptyStateContent,
+  headerContent
 }) {
   const [currentPage, setCurrentPage] = useState(1);
   const [pageInput, setPageInput] = useState(1);
@@ -119,6 +121,11 @@ export default function CollapsibleSection({
         </span>
         {title} ({questions.length})
       </h3>
+      {headerContent && !isCollapsed && (
+        <div style={{ margin: '-0.35rem 0 0.9rem 1.35rem' }}>
+          {headerContent}
+        </div>
+      )}
       
       {!isCollapsed && (
         <>

--- a/frontend/src/components/QuestionCard.jsx
+++ b/frontend/src/components/QuestionCard.jsx
@@ -98,11 +98,16 @@ export default function QuestionCard({
   showEditButton = false,
   showRemoveButton = false,
   showStudentViewButton = false,
+  showVariantButton = false,
+  showApproveButton = false,
   actionLoading = false,
+  variantLoading = false,
   onDelete,
   onEdit,
   onRemove,
   onStudentView,
+  onGenerateVariant,
+  onApproveDraft,
   compact = false,
   showUserIcon = true,
   questionNumber,
@@ -579,12 +584,12 @@ export default function QuestionCard({
       })()}
 
       {/* Action buttons */}
-      {(showStudentViewButton || showDeleteButton || showEditButton || showRemoveButton) && (
+      {(showStudentViewButton || showVariantButton || showApproveButton || showDeleteButton || showEditButton || showRemoveButton) && (
         <div 
           onPointerDown={(e) => e.stopPropagation()}
           style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', gap: '0.5rem', marginTop: '0.75rem' }}
         >
-          <div>
+          <div style={{ display: 'flex', gap: '0.5rem', flexWrap: 'wrap' }}>
             {showStudentViewButton && (
               <button
                 onClick={(e) => {
@@ -606,6 +611,56 @@ export default function QuestionCard({
                 onMouseLeave={(e) => { e.currentTarget.style.backgroundColor = '#0ea5e9'; }}
               >
                 Student View
+              </button>
+            )}
+            {showVariantButton && onGenerateVariant && (
+              <button
+                onClick={(e) => {
+                  e.stopPropagation();
+                  onGenerateVariant(question);
+                }}
+                disabled={actionLoading || variantLoading}
+                style={{
+                  padding: '0.375rem 0.75rem',
+                  background: '#0f766e',
+                  color: 'white',
+                  border: 'none',
+                  borderRadius: '6px',
+                  cursor: (actionLoading || variantLoading) ? 'not-allowed' : 'pointer',
+                  fontSize: '0.875rem',
+                  fontWeight: '500',
+                  opacity: (actionLoading || variantLoading) ? 0.6 : 1,
+                  transition: 'background-color 0.15s ease'
+                }}
+                onMouseEnter={(e) => { if (!actionLoading && !variantLoading) e.currentTarget.style.backgroundColor = '#0d9488'; }}
+                onMouseLeave={(e) => { if (!actionLoading && !variantLoading) e.currentTarget.style.backgroundColor = '#0f766e'; }}
+              >
+                {variantLoading ? 'Generating...' : 'Generate Variant'}
+              </button>
+            )}
+            {showApproveButton && onApproveDraft && (
+              <button
+                onClick={(e) => {
+                  e.stopPropagation();
+                  onApproveDraft(question);
+                }}
+                disabled={actionLoading}
+                style={{
+                  padding: '0.375rem 0.75rem',
+                  background: '#15803d',
+                  color: 'white',
+                  border: 'none',
+                  borderRadius: '6px',
+                  cursor: actionLoading ? 'not-allowed' : 'pointer',
+                  fontSize: '0.875rem',
+                  fontWeight: '500',
+                  opacity: actionLoading ? 0.6 : 1,
+                  transition: 'background-color 0.15s ease'
+                }}
+                onMouseEnter={(e) => { if (!actionLoading) e.currentTarget.style.backgroundColor = '#166534'; }}
+                onMouseLeave={(e) => { if (!actionLoading) e.currentTarget.style.backgroundColor = '#15803d'; }}
+              >
+                Approve
               </button>
             )}
           </div>

--- a/frontend/src/components/QuestionTable.jsx
+++ b/frontend/src/components/QuestionTable.jsx
@@ -194,9 +194,14 @@ const TableRow = ({
   showCourseType,
   showEditButton,
   showRemoveButton,
+  showVariantButton,
+  showApproveButton,
   onEdit,
   onRemove,
+  onGenerateVariant,
+  onApproveDraft,
   actionLoading,
+  variantLoading,
   hasActions,
   isDraggable,
 }) => {
@@ -325,6 +330,58 @@ const TableRow = ({
                 Edit
               </button>
             )}
+            {showVariantButton && onGenerateVariant && (
+              <button
+                onClick={(e) => {
+                  e.stopPropagation();
+                  onGenerateVariant(question);
+                }}
+                disabled={actionLoading || variantLoading}
+                style={{
+                  padding: '0.375rem 0.75rem',
+                  background: '#0f766e',
+                  color: 'white',
+                  border: 'none',
+                  borderRadius: '6px',
+                  cursor: (actionLoading || variantLoading) ? 'not-allowed' : 'pointer',
+                  fontSize: '0.875rem',
+                  fontWeight: '500',
+                  opacity: (actionLoading || variantLoading) ? 0.6 : 1,
+                  transition: 'background-color 0.15s ease',
+                  whiteSpace: 'nowrap'
+                }}
+                onMouseEnter={(e) => { if (!actionLoading && !variantLoading) e.currentTarget.style.backgroundColor = '#0d9488'; }}
+                onMouseLeave={(e) => { if (!actionLoading && !variantLoading) e.currentTarget.style.backgroundColor = '#0f766e'; }}
+              >
+                {variantLoading ? 'Generating...' : 'Generate Variant'}
+              </button>
+            )}
+            {showApproveButton && onApproveDraft && (
+              <button
+                onClick={(e) => {
+                  e.stopPropagation();
+                  onApproveDraft(question);
+                }}
+                disabled={actionLoading}
+                style={{
+                  padding: '0.375rem 0.75rem',
+                  background: '#15803d',
+                  color: 'white',
+                  border: 'none',
+                  borderRadius: '6px',
+                  cursor: actionLoading ? 'not-allowed' : 'pointer',
+                  fontSize: '0.875rem',
+                  fontWeight: '500',
+                  opacity: actionLoading ? 0.6 : 1,
+                  transition: 'background-color 0.15s ease',
+                  whiteSpace: 'nowrap'
+                }}
+                onMouseEnter={(e) => { if (!actionLoading) e.currentTarget.style.backgroundColor = '#166534'; }}
+                onMouseLeave={(e) => { if (!actionLoading) e.currentTarget.style.backgroundColor = '#15803d'; }}
+              >
+                Approve
+              </button>
+            )}
             {showRemoveButton && onRemove && (
               <button
                 onClick={(e) => {
@@ -434,9 +491,14 @@ export default function QuestionTable({
   showCourseType = true,
   showEditButton = false,
   showRemoveButton = false,
+  showVariantButton = false,
+  showApproveButton = false,
   onEdit,
   onRemove,
+  onGenerateVariant,
+  onApproveDraft,
   actionLoading = false,
+  variantLoadingId = null,
   isDraggable = false,
 
   selectable = false,
@@ -483,7 +545,9 @@ export default function QuestionTable({
   const hasDeletableQuestions = showActions && user &&
     questions.some(q => q.user_id === user.id);
 
-  const hasActions = showEditButton || showRemoveButton || hasDeletableQuestions;
+  const hasVariantActions = showActions && showVariantButton;
+  const hasApproveActions = showActions && showApproveButton;
+  const hasActions = showEditButton || showRemoveButton || hasVariantActions || hasApproveActions || hasDeletableQuestions;
   const hasQID = !!showQID;
   const hasCourseType = !!showCourseType;
   const hasQuestionNumber = !!showQuestionNumber;
@@ -657,9 +721,14 @@ export default function QuestionTable({
                   showCourseType={hasCourseType}
                   showEditButton={showEditButton && canDelete}
                   showRemoveButton={showRemoveButton}
+                  showVariantButton={hasVariantActions}
+                  showApproveButton={hasApproveActions}
                   onEdit={onEdit}
                   onRemove={onRemove}
+                  onGenerateVariant={onGenerateVariant}
+                  onApproveDraft={onApproveDraft}
                   actionLoading={actionLoading}
+                  variantLoading={variantLoadingId === question.id}
                   hasActions={hasActions}
                   isDraggable={isDraggable}
                   onPreview={handlePreview}

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -123,3 +123,8 @@
   }
 }
 
+@keyframes caliber-spin {
+  to {
+    transform: rotate(360deg);
+  }
+}

--- a/frontend/src/pages/QuestionBank.jsx
+++ b/frontend/src/pages/QuestionBank.jsx
@@ -4,7 +4,17 @@ import remarkGfm from 'remark-gfm';
 import remarkMath from 'remark-math';
 import rehypeKatex from 'rehype-katex';
 import 'katex/dist/katex.min.css';
-import { getQuestions, getAllQuestions, deleteQuestion, getImageSignedUrl, getUserById, getUserInfo } from '../api';
+import {
+  getQuestions,
+  getDraftQuestions,
+  getAllQuestions,
+  deleteQuestion,
+  updateQuestion,
+  generateQuestionVariant,
+  getImageSignedUrl,
+  getUserById,
+  getUserInfo
+} from '../api';
 import { useAuth } from '../AuthContext';
 import QuestionCard from '../components/QuestionCard';
 import CollapsibleSection from '../components/CollapsibleSection';
@@ -82,14 +92,43 @@ const KEYWORD_COLORS = ['#e3f2fd', '#f3e5f5', '#e8f5e9', '#fff3e0', '#fce4ec'];
 // Sort function for newest-first ordering
 const sortByNewest = (a, b) => new Date(b.created_at) - new Date(a.created_at);
 
+const BANK_TABS = {
+  QUESTIONS: 'questions',
+  DRAFTS: 'drafts',
+  ALL: 'all',
+};
+
+const getBankTabFromHash = () => {
+  const rawHash = window.location.hash.slice(1);
+  const [route, query = ''] = rawHash.split('?');
+  if (route !== 'questions') return BANK_TABS.QUESTIONS;
+
+  const params = new URLSearchParams(query);
+  const tab = (params.get('tab') || BANK_TABS.QUESTIONS).toLowerCase();
+  if (tab === BANK_TABS.DRAFTS || tab === BANK_TABS.ALL) {
+    return tab;
+  }
+  return BANK_TABS.QUESTIONS;
+};
+
+const setQuestionBankTabInHash = (tab) => {
+  if (tab && tab !== BANK_TABS.QUESTIONS) {
+    window.location.hash = `questions?tab=${tab}`;
+    return;
+  }
+  window.location.hash = 'questions';
+};
+
 export default function QuestionBank() {
   const { user } = useAuth();
   const [myQuestions, setMyQuestions] = useState([]);
+  const [draftQuestions, setDraftQuestions] = useState([]);
   const [allQuestions, setAllQuestions] = useState([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState('');
   const [deleteConfirm, setDeleteConfirm] = useState(null);
   const [myQuestionsCollapsed, setMyQuestionsCollapsed] = useState(false);
+  const [draftQuestionsCollapsed, setDraftQuestionsCollapsed] = useState(false);
   const [allQuestionsCollapsed, setAllQuestionsCollapsed] = useState(false);
   const [viewMode, setViewMode] = useState('table'); // 'card' or 'table'
   const [imageUrls, setImageUrls] = useState({}); // Cache for signed URLs
@@ -98,12 +137,67 @@ export default function QuestionBank() {
   const [searchQuery, setSearchQuery] = useState('');
   const [searchFilter, setSearchFilter] = useState('all'); // 'all', 'keywords', 'tags', 'course', 'text'
   const [studentViewQuestion, setStudentViewQuestion] = useState(null);
+  const [activeBankTab, setActiveBankTab] = useState(getBankTabFromHash);
+  const [generationModalOpen, setGenerationModalOpen] = useState(false);
+  const [generationModalQuestion, setGenerationModalQuestion] = useState(null);
+  const [variantLoadingId, setVariantLoadingId] = useState(null);
+  const [pendingVariantCount, setPendingVariantCount] = useState(0);
+  const [approveDraftQuestion, setApproveDraftQuestion] = useState(null);
+  const [approveDraftLoading, setApproveDraftLoading] = useState(false);
 
   const itemsPerPage = 6;
 
   // Filtered questions
   const filteredMyQuestions = filterQuestionsBySearch(myQuestions, searchQuery, searchFilter);
+  const filteredDraftQuestions = filterQuestionsBySearch(draftQuestions, searchQuery, searchFilter);
   const filteredAllQuestions = filterQuestionsBySearch(allQuestions, searchQuery, searchFilter);
+  const activeQuestions =
+    activeBankTab === BANK_TABS.DRAFTS
+      ? filteredDraftQuestions
+      : activeBankTab === BANK_TABS.ALL
+        ? filteredAllQuestions
+        : filteredMyQuestions;
+
+  const draftGenerationStatus = pendingVariantCount > 0
+    ? `${pendingVariantCount} generating...`
+    : '';
+
+  const hydrateQuestionMetadata = async (questions, replace = false) => {
+    const imageQuestions = questions.filter(q => q.image_url);
+    const urlPromises = imageQuestions.map(async (q) => {
+      const signedUrl = await getImageSignedUrl(q.image_url);
+      return { id: q.id, url: signedUrl };
+    });
+
+    const urls = await Promise.all(urlPromises);
+    const urlMap = {};
+    urls.forEach(({ id, url }) => {
+      if (url) {
+        urlMap[id] = url;
+      }
+    });
+    setImageUrls(prev => (replace ? urlMap : { ...prev, ...urlMap }));
+
+    const uniqueUserIds = [...new Set(questions.map(q => q.user_id).filter(Boolean))];
+    const userPromises = uniqueUserIds.map(async (userId) => {
+      try {
+        const userInfo = await getUserById(userId);
+        return { userId, userInfo };
+      } catch (error) {
+        console.error(`Failed to fetch user ${userId}:`, error);
+        return { userId, userInfo: null };
+      }
+    });
+
+    const users = await Promise.all(userPromises);
+    const userMap = {};
+    users.forEach(({ userId, userInfo }) => {
+      if (userInfo) {
+        userMap[userId] = userInfo;
+      }
+    });
+    setUserInfoCache(prev => (replace ? userMap : { ...prev, ...userMap }));
+  };
 
   // Fetch current user info to check if they are a teacher
   useEffect(() => {
@@ -121,12 +215,23 @@ export default function QuestionBank() {
     }
   }, [user]);
 
-  const loadQuestions = async () => {
+  useEffect(() => {
+    const syncTabFromHash = () => {
+      setActiveBankTab(getBankTabFromHash());
+    };
+
+    syncTabFromHash();
+    window.addEventListener('hashchange', syncTabFromHash);
+    return () => window.removeEventListener('hashchange', syncTabFromHash);
+  }, []);
+
+  const loadBankData = async () => {
     setLoading(true);
     setError('');
     try {
-      const [myData, allData] = await Promise.all([
-        getQuestions({ limit: 1000 }),
+      const [myData, draftData, allData] = await Promise.all([
+        getQuestions({ verified_only: true, limit: 1000 }),
+        getDraftQuestions({ limit: 1000 }),
         getAllQuestions({ limit: 1000 })
       ]);
 
@@ -135,49 +240,18 @@ export default function QuestionBank() {
         .filter(q => q.is_verified === true)
         .sort(sortByNewest);
 
+      const draftMyQuestions = (draftData.questions || [])
+        .filter(q => q.is_verified === false)
+        .sort(sortByNewest);
+
       const verifiedAllQuestions = (allData.questions || [])
         .filter(q => q.is_verified === true)
         .sort(sortByNewest);
 
       setMyQuestions(verifiedMyQuestions);
+      setDraftQuestions(draftMyQuestions);
       setAllQuestions(verifiedAllQuestions);
-
-      // Generate signed URLs for all questions with images
-      const allQuestionsWithImages = [...verifiedMyQuestions, ...verifiedAllQuestions].filter(q => q.image_url);
-      const urlPromises = allQuestionsWithImages.map(async (q) => {
-        const signedUrl = await getImageSignedUrl(q.image_url);
-        return { id: q.id, url: signedUrl };
-      });
-
-      const urls = await Promise.all(urlPromises);
-      const urlMap = {};
-      urls.forEach(({ id, url }) => {
-        if (url) {
-          urlMap[id] = url;
-        }
-      });
-      setImageUrls(urlMap);
-
-      // Fetch user info for all questions
-      const uniqueUserIds = [...new Set([...verifiedMyQuestions, ...verifiedAllQuestions].map(q => q.user_id))];
-      const userPromises = uniqueUserIds.map(async (userId) => {
-        try {
-          const userInfo = await getUserById(userId);
-          return { userId, userInfo };
-        } catch (error) {
-          console.error(`Failed to fetch user ${userId}:`, error);
-          return { userId, userInfo: null };
-        }
-      });
-
-      const users = await Promise.all(userPromises);
-      const userMap = {};
-      users.forEach(({ userId, userInfo }) => {
-        if (userInfo) {
-          userMap[userId] = userInfo;
-        }
-      });
-      setUserInfoCache(userMap);
+      await hydrateQuestionMetadata([...verifiedMyQuestions, ...draftMyQuestions, ...verifiedAllQuestions], true);
     } catch (err) {
       setError(err.message || 'Failed to load questions');
     } finally {
@@ -186,17 +260,78 @@ export default function QuestionBank() {
   };
 
   useEffect(() => {
-    loadQuestions();
+    loadBankData();
   }, []);
+
+  const refreshDraftQuestions = async () => {
+    try {
+      const draftData = await getDraftQuestions({ limit: 1000 });
+      const draftMyQuestions = (draftData.questions || []).sort(sortByNewest);
+      setDraftQuestions(draftMyQuestions);
+      await hydrateQuestionMetadata(draftMyQuestions, false);
+    } catch (err) {
+      console.error('Failed to refresh draft questions:', err);
+    }
+  };
 
   const handleDelete = async (questionId) => {
     try {
       await deleteQuestion(questionId);
       setDeleteConfirm(null);
-      await loadQuestions();
+      await loadBankData();
     } catch (err) {
       setError(err.message || 'Failed to delete question');
     }
+  };
+
+  const openApproveDraftModal = (question) => {
+    setApproveDraftQuestion(question);
+  };
+
+  const closeApproveDraftModal = () => {
+    setApproveDraftQuestion(null);
+    setApproveDraftLoading(false);
+  };
+
+  const handleApproveDraft = async () => {
+    if (!approveDraftQuestion) return;
+    setApproveDraftLoading(true);
+    try {
+      await updateQuestion(approveDraftQuestion.id, { is_verified: true });
+      closeApproveDraftModal();
+      await loadBankData();
+    } catch (err) {
+      setError(err.message || 'Failed to approve draft question');
+      setApproveDraftLoading(false);
+    }
+  };
+
+  const handleGenerateVariant = async (question) => {
+    setVariantLoadingId(question.id);
+    setPendingVariantCount((count) => count + 1);
+    setGenerationModalQuestion(question);
+    setGenerationModalOpen(true);
+    try {
+      await generateQuestionVariant(question.id);
+      await refreshDraftQuestions();
+    } catch (err) {
+      setError(err.message || 'Failed to generate question variant');
+    } finally {
+      setVariantLoadingId(null);
+      setPendingVariantCount((count) => Math.max(0, count - 1));
+    }
+  };
+
+  const closeGenerationModal = () => {
+    setGenerationModalOpen(false);
+    setGenerationModalQuestion(null);
+    setVariantLoadingId(null);
+  };
+
+  const openBankTab = (tab) => {
+    setActiveBankTab(tab);
+    closeGenerationModal();
+    setQuestionBankTabInHash(tab);
   };
 
   // Wrapper function to render table view using QuestionTable component
@@ -207,8 +342,13 @@ export default function QuestionBank() {
         userInfoCache={userInfoCache}
         user={user}
         showEditButton={isTeacher}
+        showVariantButton={isTeacher && activeBankTab !== BANK_TABS.DRAFTS}
+        showApproveButton={activeBankTab === BANK_TABS.DRAFTS}
+        variantLoadingId={variantLoadingId}
         showUniversity={true}
         onDelete={(id) => setDeleteConfirm(id)}
+        onGenerateVariant={handleGenerateVariant}
+        onApproveDraft={openApproveDraftModal}
       />
     );
   };
@@ -223,8 +363,13 @@ export default function QuestionBank() {
         showDeleteButton={showDeleteButton}
         showEditButton={showEditButton}
         showStudentViewButton={true}
+        showVariantButton={isTeacher && activeBankTab !== BANK_TABS.DRAFTS}
+        showApproveButton={activeBankTab === BANK_TABS.DRAFTS}
+        variantLoading={variantLoadingId === question.id}
         onDelete={(id) => setDeleteConfirm(id)}
         onStudentView={(q) => setStudentViewQuestion(q)}
+        onGenerateVariant={handleGenerateVariant}
+        onApproveDraft={openApproveDraftModal}
       />
     );
   };
@@ -255,7 +400,7 @@ export default function QuestionBank() {
             Question Bank
           </h1>
           <p style={{ margin: '0.45rem 0 0 0', color: '#475569', fontSize: '0.95rem' }}>
-            Search verified prompts quickly and use AI upload to generate new drafts from PDFs.
+            Browse verified questions, generated drafts, and AI-created variants from one place.
           </p>
         </div>
 
@@ -327,7 +472,7 @@ export default function QuestionBank() {
           </button>
 
           <button
-            onClick={loadQuestions}
+            onClick={loadBankData}
             disabled={loading}
             title={loading ? 'Refreshing questions' : 'Refresh questions'}
             aria-label={loading ? 'Refreshing questions' : 'Refresh questions'}
@@ -393,9 +538,75 @@ export default function QuestionBank() {
         onSearchFilterChange={setSearchFilter}
         onClearSearch={() => setSearchQuery('')}
         showResultCount={Boolean(searchQuery)}
-        resultCount={filteredMyQuestions.length + filteredAllQuestions.length}
+        resultCount={activeQuestions.length}
         containerStyle={{ marginBottom: '1.7rem' }}
       />
+
+      <div style={{ marginBottom: '1rem' }}>
+        <div
+          style={{
+            display: 'inline-flex',
+            background: '#f8fafc',
+            border: '1px solid #dbe5f1',
+            borderRadius: '11px',
+            padding: '0.25rem',
+            gap: '0.25rem',
+            flexWrap: 'wrap'
+          }}
+        >
+          <button
+            onClick={() => openBankTab(BANK_TABS.QUESTIONS)}
+            style={{
+              padding: '0.45rem 0.9rem',
+              background: activeBankTab === BANK_TABS.QUESTIONS ? '#ffffff' : 'transparent',
+              color: activeBankTab === BANK_TABS.QUESTIONS ? '#0f172a' : '#64748b',
+              border: 'none',
+              borderRadius: '8px',
+              cursor: 'pointer',
+              fontSize: '0.82rem',
+              fontWeight: activeBankTab === BANK_TABS.QUESTIONS ? '700' : '600',
+              boxShadow: activeBankTab === BANK_TABS.QUESTIONS ? '0 1px 3px rgba(15,23,42,0.12)' : 'none',
+              transition: 'all 0.15s ease'
+            }}
+          >
+            My Questions
+          </button>
+          <button
+            onClick={() => openBankTab(BANK_TABS.DRAFTS)}
+            style={{
+              padding: '0.45rem 0.9rem',
+              background: activeBankTab === BANK_TABS.DRAFTS ? '#ffffff' : 'transparent',
+              color: activeBankTab === BANK_TABS.DRAFTS ? '#0f172a' : '#64748b',
+              border: 'none',
+              borderRadius: '8px',
+              cursor: 'pointer',
+              fontSize: '0.82rem',
+              fontWeight: activeBankTab === BANK_TABS.DRAFTS ? '700' : '600',
+              boxShadow: activeBankTab === BANK_TABS.DRAFTS ? '0 1px 3px rgba(15,23,42,0.12)' : 'none',
+              transition: 'all 0.15s ease'
+            }}
+          >
+            My Drafts
+          </button>
+          <button
+            onClick={() => openBankTab(BANK_TABS.ALL)}
+            style={{
+              padding: '0.45rem 0.9rem',
+              background: activeBankTab === BANK_TABS.ALL ? '#ffffff' : 'transparent',
+              color: activeBankTab === BANK_TABS.ALL ? '#0f172a' : '#64748b',
+              border: 'none',
+              borderRadius: '8px',
+              cursor: 'pointer',
+              fontSize: '0.82rem',
+              fontWeight: activeBankTab === BANK_TABS.ALL ? '700' : '600',
+              boxShadow: activeBankTab === BANK_TABS.ALL ? '0 1px 3px rgba(15,23,42,0.12)' : 'none',
+              transition: 'all 0.15s ease'
+            }}
+          >
+            All Questions
+          </button>
+        </div>
+      </div>
 
       {loading && <p style={{ color: '#64748b', fontWeight: 600 }}>Loading questions...</p>}
 
@@ -461,6 +672,77 @@ export default function QuestionBank() {
                 }}
               >
                 Delete
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
+
+      {approveDraftQuestion && (
+        <div
+          style={{
+            position: 'fixed',
+            inset: 0,
+            background: 'rgba(15, 23, 42, 0.56)',
+            display: 'flex',
+            alignItems: 'center',
+            justifyContent: 'center',
+            zIndex: 1100,
+            padding: '1rem'
+          }}
+          onClick={closeApproveDraftModal}
+        >
+          <div
+            style={{
+              background: 'white',
+              padding: '1.5rem',
+              borderRadius: '12px',
+              width: 'min(460px, 100%)',
+              border: '1px solid #e5e7eb',
+              boxShadow: '0 18px 50px rgba(15, 23, 42, 0.2)'
+            }}
+            onClick={(e) => e.stopPropagation()}
+          >
+            <h3 style={{ marginTop: 0, marginBottom: '0.65rem', color: '#0f172a' }}>
+              Approve Draft
+            </h3>
+            <p style={{ marginTop: 0, marginBottom: '1.25rem', color: '#475569', lineHeight: 1.5 }}>
+              Are you sure you want to approve this draft? This will save the question into our question database.
+            </p>
+            <div style={{ display: 'flex', gap: '0.75rem', justifyContent: 'flex-end' }}>
+              <button
+                type="button"
+                onClick={closeApproveDraftModal}
+                disabled={approveDraftLoading}
+                style={{
+                  padding: '0.55rem 0.9rem',
+                  border: '1px solid #d1d5db',
+                  background: 'white',
+                  color: '#374151',
+                  borderRadius: '8px',
+                  cursor: approveDraftLoading ? 'not-allowed' : 'pointer',
+                  fontWeight: '600',
+                  opacity: approveDraftLoading ? 0.6 : 1
+                }}
+              >
+                Cancel
+              </button>
+              <button
+                type="button"
+                onClick={handleApproveDraft}
+                disabled={approveDraftLoading}
+                style={{
+                  padding: '0.55rem 0.9rem',
+                  border: 'none',
+                  background: '#15803d',
+                  color: 'white',
+                  borderRadius: '8px',
+                  cursor: approveDraftLoading ? 'not-allowed' : 'pointer',
+                  fontWeight: '700',
+                  opacity: approveDraftLoading ? 0.7 : 1
+                }}
+              >
+                {approveDraftLoading ? 'Approving...' : 'Approve'}
               </button>
             </div>
           </div>
@@ -533,6 +815,87 @@ export default function QuestionBank() {
         </div>
       )}
 
+      {generationModalOpen && (
+        <div
+          style={{
+            position: 'fixed',
+            inset: '64px 0 0 0',
+            background: 'rgba(0,0,0,0.5)',
+            zIndex: 1250,
+            display: 'flex',
+            justifyContent: 'center',
+            alignItems: 'flex-start',
+            overflowY: 'auto',
+            padding: '1rem'
+          }}
+          onClick={closeGenerationModal}
+        >
+          <div
+            style={{
+              width: 'min(720px, 100%)',
+              background: 'white',
+              borderRadius: '12px',
+              border: '1px solid #e5e7eb',
+              boxShadow: '0 25px 60px rgba(15, 23, 42, 0.22)',
+              padding: '1.5rem'
+            }}
+            onClick={(e) => e.stopPropagation()}
+          >
+            <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'flex-start', gap: '1rem' }}>
+              <div>
+                <div style={{ fontSize: '1.15rem', fontWeight: 800, color: '#0f172a', marginBottom: '0.45rem' }}>
+                  Variant generation started
+                </div>
+                <p style={{ margin: 0, color: '#475569', fontSize: '0.98rem', lineHeight: 1.5 }}>
+                  Variant generation is happening in the background and may take a minute.
+                </p>
+                {generationModalQuestion?.title ? (
+                  <p style={{ margin: '0.75rem 0 0 0', color: '#64748b', fontSize: '0.9rem' }}>
+                    Source: {generationModalQuestion.title}
+                  </p>
+                ) : null}
+              </div>
+              <button
+                type="button"
+                onClick={closeGenerationModal}
+                style={{
+                  padding: '0.4rem 0.6rem',
+                  border: '1px solid #d1d5db',
+                  background: 'white',
+                  color: '#475569',
+                  borderRadius: '8px',
+                  cursor: 'pointer',
+                  fontWeight: '600'
+                }}
+              >
+                Close
+              </button>
+            </div>
+
+            <div style={{ display: 'flex', gap: '0.75rem', marginTop: '1.25rem', flexWrap: 'wrap' }}>
+              <button
+                type="button"
+                onClick={() => {
+                  closeGenerationModal();
+                  openBankTab(BANK_TABS.DRAFTS);
+                }}
+                style={{
+                  padding: '0.65rem 0.95rem',
+                  border: 'none',
+                  background: '#4f46e5',
+                  color: 'white',
+                  borderRadius: '9px',
+                  cursor: 'pointer',
+                  fontWeight: '700'
+                }}
+              >
+                My Drafts
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
+
       {!loading && (
         <>
           <div style={{ marginBottom: '1rem' }}>
@@ -583,85 +946,152 @@ export default function QuestionBank() {
             </div>
           </div>
 
-          {/* My Questions Section */}
-          <div style={{ marginBottom: '4rem' }}>
-            <CollapsibleSection
-              title={searchQuery ? `My Questions (${filteredMyQuestions.length} of ${myQuestions.length})` : "My Questions"}
-              questions={filteredMyQuestions}
-              isCollapsed={myQuestionsCollapsed}
-              onToggle={() => setMyQuestionsCollapsed(!myQuestionsCollapsed)}
-              borderColor="#007bff"
-              viewMode={viewMode}
-              itemsPerPage={itemsPerPage}
-              renderTableView={renderTableView}
-              renderQuestionCard={renderQuestionCard}
-              user={user}
-              isTeacher={isTeacher}
-              emptyStateContent={
-                <div style={{
-                  padding: '2rem',
-                  background: '#f8f9fa',
-                  borderRadius: '4px',
-                  textAlign: 'center',
-                  color: '#666'
-                }}>
-                  {searchQuery ? (
-                    <p>No questions match your search in "My Questions".</p>
-                  ) : (
-                    <>
-                      <p>You haven't created any questions yet.</p>
-                      <button
-                        onClick={() => window.location.hash = 'create-question'}
-                        style={{
-                          marginTop: '1rem',
-                          padding: '0.5rem 1rem',
-                          background: '#28a745',
-                          color: 'white',
-                          border: 'none',
-                          borderRadius: '4px',
-                          cursor: 'pointer'
-                        }}
-                      >
-                        Create Your First Question
-                      </button>
-                    </>
-                  )}
-                </div>
-              }
-            />
-          </div>
+          {activeBankTab === BANK_TABS.QUESTIONS && (
+            <div style={{ marginBottom: '4rem' }}>
+              <CollapsibleSection
+                title={searchQuery ? `My Questions (${filteredMyQuestions.length} of ${myQuestions.length})` : "My Questions"}
+                questions={filteredMyQuestions}
+                isCollapsed={myQuestionsCollapsed}
+                onToggle={() => setMyQuestionsCollapsed(!myQuestionsCollapsed)}
+                borderColor="#007bff"
+                viewMode={viewMode}
+                itemsPerPage={itemsPerPage}
+                renderTableView={renderTableView}
+                renderQuestionCard={renderQuestionCard}
+                user={user}
+                isTeacher={isTeacher}
+                emptyStateContent={
+                  <div style={{
+                    padding: '2rem',
+                    background: '#f8f9fa',
+                    borderRadius: '4px',
+                    textAlign: 'center',
+                    color: '#666'
+                  }}>
+                    {searchQuery ? (
+                      <p>No questions match your search in "My Questions".</p>
+                    ) : (
+                      <>
+                        <p>You haven't created any questions yet.</p>
+                        <button
+                          onClick={() => window.location.hash = 'create-question'}
+                          style={{
+                            marginTop: '1rem',
+                            padding: '0.5rem 1rem',
+                            background: '#28a745',
+                            color: 'white',
+                            border: 'none',
+                            borderRadius: '4px',
+                            cursor: 'pointer'
+                          }}
+                        >
+                          Create Your First Question
+                        </button>
+                      </>
+                    )}
+                  </div>
+                }
+              />
+            </div>
+          )}
 
-          {/* All Questions Section */}
-          <div>
-            <CollapsibleSection
-              title={searchQuery ? `All Questions (${filteredAllQuestions.length} of ${allQuestions.length})` : "All Questions"}
-              questions={filteredAllQuestions}
-              isCollapsed={allQuestionsCollapsed}
-              onToggle={() => setAllQuestionsCollapsed(!allQuestionsCollapsed)}
-              borderColor="#28a745"
-              viewMode={viewMode}
-              itemsPerPage={itemsPerPage}
-              renderTableView={renderTableView}
-              renderQuestionCard={renderQuestionCard}
-              user={user}
-              isTeacher={isTeacher}
-              emptyStateContent={
-                <div style={{
-                  padding: '2rem',
-                  background: '#f8f9fa',
-                  borderRadius: '4px',
-                  textAlign: 'center',
-                  color: '#666'
-                }}>
-                  {searchQuery ? (
-                    <p>No questions match your search in "All Questions".</p>
-                  ) : (
-                    <p>No questions found in the system.</p>
-                  )}
-                </div>
-              }
-            />
-          </div>
+          {activeBankTab === BANK_TABS.DRAFTS && (
+            <div style={{ marginBottom: '4rem' }}>
+              <CollapsibleSection
+                title="My Drafts"
+                questions={filteredDraftQuestions}
+                isCollapsed={draftQuestionsCollapsed}
+                onToggle={() => setDraftQuestionsCollapsed(!draftQuestionsCollapsed)}
+                borderColor="#4f46e5"
+                viewMode={viewMode}
+                itemsPerPage={itemsPerPage}
+                renderTableView={renderTableView}
+                renderQuestionCard={renderQuestionCard}
+                user={user}
+                isTeacher={isTeacher}
+                headerContent={
+                  draftGenerationStatus ? (
+                    <div
+                      style={{
+                        display: 'inline-flex',
+                        alignItems: 'center',
+                        gap: '0.65rem',
+                        padding: '0.55rem 0.75rem',
+                        background: 'rgba(79, 70, 229, 0.08)',
+                        border: '1px solid rgba(79, 70, 229, 0.18)',
+                        borderRadius: '999px',
+                        color: '#4338ca',
+                        fontSize: '0.85rem',
+                        fontWeight: 700,
+                        boxShadow: '0 1px 2px rgba(15,23,42,0.06)'
+                      }}
+                    >
+                      <span
+                        style={{
+                          width: '16px',
+                          height: '16px',
+                          borderRadius: '50%',
+                          border: '2px solid rgba(67, 56, 202, 0.25)',
+                          borderTopColor: '#4338ca',
+                          animation: 'caliber-spin 0.8s linear infinite',
+                          flexShrink: 0
+                        }}
+                      />
+                      {draftGenerationStatus}
+                    </div>
+                  ) : null
+                }
+                emptyStateContent={
+                  <div style={{
+                    padding: '2rem',
+                    background: '#f8f9fa',
+                    borderRadius: '4px',
+                    textAlign: 'center',
+                    color: '#666'
+                  }}>
+                    {searchQuery ? (
+                      <p>No drafts match your search in "My Drafts".</p>
+                    ) : (
+                      <p>You do not have any draft questions yet.</p>
+                    )}
+                  </div>
+                }
+              />
+            </div>
+          )}
+
+          {activeBankTab === BANK_TABS.ALL && (
+            <div style={{ marginBottom: '4rem' }}>
+              <CollapsibleSection
+                title={searchQuery ? `All Questions (${filteredAllQuestions.length} of ${allQuestions.length})` : "All Questions"}
+                questions={filteredAllQuestions}
+                isCollapsed={allQuestionsCollapsed}
+                onToggle={() => setAllQuestionsCollapsed(!allQuestionsCollapsed)}
+                borderColor="#28a745"
+                viewMode={viewMode}
+                itemsPerPage={itemsPerPage}
+                renderTableView={renderTableView}
+                renderQuestionCard={renderQuestionCard}
+                user={user}
+                isTeacher={isTeacher}
+                emptyStateContent={
+                  <div style={{
+                    padding: '2rem',
+                    background: '#f8f9fa',
+                    borderRadius: '4px',
+                    textAlign: 'center',
+                    color: '#666'
+                  }}>
+                    {searchQuery ? (
+                      <p>No questions match your search in "All Questions".</p>
+                    ) : (
+                      <p>No questions found in the system.</p>
+                    )}
+                  </div>
+                }
+              />
+            </div>
+          )}
         </>
       )}
     </div>


### PR DESCRIPTION
This pull request introduces a new AI-powered question variant generation pipeline and exposes it via new backend API endpoints. The main changes include environment variable additions for model configuration, new CRUD methods and endpoints for managing draft questions, core logic for generating and saving variants, and the addition of a detailed design document and public API for the variant generation module.

**Summary of most important changes:**

### Variant Generation Core & API

* Added a new API endpoint `/api/questions/{question_id}/variants` that generates AI-powered variants for a given question and saves them as unverified draft questions for the current user. This includes logic for validating question ownership and formatting variant drafts.
* Implemented core utility functions in `main.py` for normalizing variant types, answers, and saving generated variants as draft questions.
* Integrated the variant generation pipeline into the backend by importing and using `generate_variant` and `question_to_variant_gen_db` from the new `variant_gen` module.

### Draft Question Management

* Added new CRUD functions `get_draft_questions` and `get_draft_questions_count` to fetch and count unverified draft questions for a user, and exposed a new `/api/questions/drafts` endpoint to retrieve them. [[1]](diffhunk://#diff-cc3e361846c868a9ed1d0769bcb0a9db4e325a915f828969b86be2f0d8b973a2R88-R98) [[2]](diffhunk://#diff-cc3e361846c868a9ed1d0769bcb0a9db4e325a915f828969b86be2f0d8b973a2R113-R117) [[3]](diffhunk://#diff-82608d38c4441937a3cfb9ff7da1bed9dd59292dec62308de75bfaa2809419a3R35) [[4]](diffhunk://#diff-82608d38c4441937a3cfb9ff7da1bed9dd59292dec62308de75bfaa2809419a3R1415-R1431)

### Environment & Configuration

* Introduced new environment variables in `.env.example` for configuring the variant generation LLM provider (`VARIANT_LLM_PROVIDER`), model keys, and vision settings, supporting both Gemini and OpenRouter providers.

### Documentation & Public API

* Added a comprehensive design document (`variant_gen/DESIGN.md`) explaining the philosophy, routing, validation, environment variables, and known trade-offs of the variant generation pipeline.
* Created a public API for the `variant_gen` module with lazy attribute loading, making it easier to use in both CLI and backend contexts.

Overall, these changes enable AI-driven question variant generation, draft management, and provide clear documentation and configuration for future development and maintenance.