### PR TITLE
Variant Generation - Coding Question Type

### DIFF
--- a/backend/app/variant_gen/DESIGN.md
+++ b/backend/app/variant_gen/DESIGN.md
@@ -44,11 +44,13 @@ Tail trim: boilerplate headings like “answer key” / “solutions to…” ge
 
 ## Routing (`question_contract`, `question_inputs`, `question_router`)
 
-Everything downstream reads a **`QuestionContract`**: `language`, `mode`, `allow_thematic_reskin`, `question_format` (MCQ / FREE_RESPONSE / TRUE_FALSE), **`expected_mcq_options`** (how strictly we enforce MCQ option count), `routing_source`.
+Everything downstream reads a **`QuestionContract`**: `language`, `mode`, `allow_thematic_reskin`, **`question_format`** (`MCQ` | `FREE_RESPONSE` | `CODING` | `TRUE_FALSE`), **`expected_mcq_options`**, **`autograde_kind`**, `routing_source`.
+
+**Formats:** **`FREE_RESPONSE`** is prose, traces, short answers, and **fill-in-the-blank / one-hole code** (still code-shaped answers sometimes, but not the “full implementation” autograder path). **`CODING`** is routed only when ``stem_routes_as_coding_format`` says so: same broad “asks for code” phrases as validators, **minus** obvious blank/fill-in stems (see ``question_inputs.py``). **`autograde_kind`** matches **`question_format`**.
 
 **`route_stem(text)`** is the only entry from `generator.py`. Rules path = `build_question_contract`. Optional **`QUESTION_ROUTER=llm`**: one small JSON call sets `question_format` + `language` only; mode and reskin stay rule-derived so we don’t accidentally enable parking-lot reskins on trace questions. Bad router output → rules fallback (one console line).
 
-**Format (`detect_format`)** order matters: true/false stubs early; “write a function / pseudocode” forces FR before loose MCQ regexes; numbered multi-part worksheets can look like MCQ lines—bail to FR; `(a)`–`(e)` plus “which of the following” catches AP-style lettered answers that `A.` regexes miss.
+**Format (`detect_format`)** order matters: true/false stubs early; **`stem_routes_as_coding_format`** (substantial implementation, not fill-in-blank) → **`CODING`** before MCQ heuristics; numbered multi-part worksheets can look like MCQ lines—bail to **FREE_RESPONSE**; `(a)`–`(e)` plus “which of the following” catches AP-style lettered answers that `A.` regexes miss.
 
 **Language** tries Java/AP signals before the loose C++ `int x = …;` heuristic so snippets without `import` don’t land as Python. Stanford-style `VectorNew` / `VectorSplit` + no `std::` → **`generic`** so we don’t demand C++-shaped answers for C. **`_mentions_cpp_as_required_language`** exists because “no C++ whatsoever” still contains the substring `c++`. Default fallthrough is still **python** for ambiguous prose (Scheme, etc.): that’s lazy but fixable with `QUESTION_LANG` or the router.
 
@@ -62,15 +64,12 @@ Everything downstream reads a **`QuestionContract`**: `language`, `mode`, `allow
 
 | Variable | Role |
 |----------|------|
-| `VARIANT_LLM_PROVIDER` | `gemini` or `openrouter`; Milestone 1 default is `gemini` |
-| `GEMINI_API_KEY` / `GOOGLE_API_KEY` | Required when `VARIANT_LLM_PROVIDER=gemini` |
-| `GEMINI_MODEL` | Gemini generate + verify model, default `gemini-3.1-flash-lite-preview` |
-| `OPENROUTER_API_KEY` | Required when `VARIANT_LLM_PROVIDER=openrouter` |
-| `OPENROUTER_MODEL` | OpenRouter generate + verify slug default |
-| `OPENROUTER_TIMEOUT` | Generate read timeout (s), default 90; shared by Gemini unless overridden per call |
+| `OPENROUTER_API_KEY` | Required for any LLM call |
+| `OPENROUTER_MODEL` | Generate + verify slug default |
+| `OPENROUTER_TIMEOUT` | Generate read timeout (s), default 90 |
 | `OPENROUTER_TIMEOUT_VERIFY` | Verify read timeout (s), default 55 |
-| `VARIANT_LLM_HTTP_RETRIES` / `OPENROUTER_HTTP_RETRIES` | TLS/connection retries, default 3 |
-| `VARIANT_LLM_VISION` / `OPENROUTER_VISION` / `OPENROUTER_SEND_IMAGES` | Disable with `0`/`false` to force text-only |
+| `OPENROUTER_HTTP_RETRIES` | TLS/connection retries, default 3 |
+| `OPENROUTER_VISION` / `OPENROUTER_SEND_IMAGES` | Disable with `0`/`false` to force text-only |
 | `GENERATION_SOURCE_MAX_CHARS` | Clip stem for generation prompt |
 | `VERIFY_VARIANT_TEXT_MAX_CHARS` | Clip `variant_text` embedded in verify |
 | `QUESTION_LANG` | Force `python` / `cpp` / `java` / `generic` for a whole run |

--- a/backend/app/variant_gen/generator.py
+++ b/backend/app/variant_gen/generator.py
@@ -6,7 +6,7 @@ Supporting modules:
   ``question_inputs`` — skip/vision/format and coarse algorithm tag from raw text.
   ``prompts`` — generation and verification prompt strings.
   ``variant_validation`` — deterministic JSON checks and answer normalization.
-  ``llm_client`` — provider JSON calls.
+  ``llm_client`` — OpenRouter JSON calls.
   ``exam_tests_questions`` — default question DB from PDFs (or env override).
 """
 
@@ -18,9 +18,8 @@ from .config import (
     MAX_RETRIES,
     generation_source_max_chars,
     openrouter_timeout_verify,
-    resolved_llm_model,
+    resolved_openrouter_model,
     telemetry_enabled,
-    variant_llm_provider,
 )
 from .exam_tests_questions import load_questions_database
 from .llm_client import call_llm, text_model_supports_images
@@ -97,7 +96,7 @@ def generate_variant(index, db_path=None, ingestion_index=-1, questions_db=None)
         image_paths = [q["image_crops"][0]]
     elif use_vision and not text_model_supports_images() and DEBUG:
         print(
-            "[DEBUG] Vision requested but variant vision is disabled; "
+            "[DEBUG] Vision requested but OPENROUTER_VISION / OPENROUTER_SEND_IMAGES disabled; "
             "using question text only."
         )
 
@@ -105,12 +104,11 @@ def generate_variant(index, db_path=None, ingestion_index=-1, questions_db=None)
     contract = route_stem(q.get("text", "") or "")
     forced_type = contract.question_format
     expected_mcq_options = contract.expected_mcq_options
-    provider_label = variant_llm_provider()
-    gen_label = resolved_llm_model(provider_label)
+    gen_label = resolved_openrouter_model()
     print(
         f"Format: {forced_type} | Algorithm: {algorithm} | Mode: {contract.mode} | "
         f"Lang: {contract.language} | Reskin: {contract.allow_thematic_reskin} | "
-        f"Route: {contract.routing_source} | LLM: {provider_label}/{gen_label}"
+        f"Route: {contract.routing_source} | Gen Model: {gen_label}"
     )
     qid = q.get("question_id") or ""
     if telemetry_enabled():
@@ -163,7 +161,7 @@ def generate_variant(index, db_path=None, ingestion_index=-1, questions_db=None)
         late_fr = free_response_correct_answer_invalid(
             gen_ans, variant, contract.language, contract, q.get("text", "")
         )
-        if forced_type == "FREE_RESPONSE" and late_fr:
+        if forced_type in ("FREE_RESPONSE", "CODING") and late_fr:
             print(f"  Invalid correct_answer: {late_fr}")
             continue
 
@@ -215,6 +213,7 @@ def generate_variant(index, db_path=None, ingestion_index=-1, questions_db=None)
                     else len(ingestions) + ingestion_index
                 ),
                 "type": forced_type,
+                "autograde_kind": contract.autograde_kind,
                 "language": contract.language,
                 "question_mode": contract.mode,
                 "routing": contract.routing_source,

--- a/backend/app/variant_gen/generator.py
+++ b/backend/app/variant_gen/generator.py
@@ -6,7 +6,7 @@ Supporting modules:
   ``question_inputs`` — skip/vision/format and coarse algorithm tag from raw text.
   ``prompts`` — generation and verification prompt strings.
   ``variant_validation`` — deterministic JSON checks and answer normalization.
-  ``llm_client`` — OpenRouter JSON calls.
+  ``llm_client`` — provider JSON calls.
   ``exam_tests_questions`` — default question DB from PDFs (or env override).
 """
 
@@ -18,8 +18,9 @@ from .config import (
     MAX_RETRIES,
     generation_source_max_chars,
     openrouter_timeout_verify,
-    resolved_openrouter_model,
+    resolved_llm_model,
     telemetry_enabled,
+    variant_llm_provider,
 )
 from .exam_tests_questions import load_questions_database
 from .llm_client import call_llm, text_model_supports_images
@@ -96,7 +97,7 @@ def generate_variant(index, db_path=None, ingestion_index=-1, questions_db=None)
         image_paths = [q["image_crops"][0]]
     elif use_vision and not text_model_supports_images() and DEBUG:
         print(
-            "[DEBUG] Vision requested but OPENROUTER_VISION / OPENROUTER_SEND_IMAGES disabled; "
+            "[DEBUG] Vision requested but variant vision is disabled; "
             "using question text only."
         )
 
@@ -104,11 +105,12 @@ def generate_variant(index, db_path=None, ingestion_index=-1, questions_db=None)
     contract = route_stem(q.get("text", "") or "")
     forced_type = contract.question_format
     expected_mcq_options = contract.expected_mcq_options
-    gen_label = resolved_openrouter_model()
+    provider_label = variant_llm_provider()
+    gen_label = resolved_llm_model(provider_label)
     print(
         f"Format: {forced_type} | Algorithm: {algorithm} | Mode: {contract.mode} | "
         f"Lang: {contract.language} | Reskin: {contract.allow_thematic_reskin} | "
-        f"Route: {contract.routing_source} | Gen Model: {gen_label}"
+        f"Route: {contract.routing_source} | LLM: {provider_label}/{gen_label}"
     )
     qid = q.get("question_id") or ""
     if telemetry_enabled():

--- a/backend/app/variant_gen/prompts.py
+++ b/backend/app/variant_gen/prompts.py
@@ -11,7 +11,6 @@ from .question_contract import (
     looks_like_named_function_write_task,
 )
 from .question_inputs import count_options
-from .variant_validation import original_asks_for_code_submission
 
 
 def _verify_output_only_hint(variant_text: str) -> str:
@@ -93,19 +92,24 @@ def prompt_extras(original_text: str, forced_type: str, style: str, contract: Qu
             "for the standard used in the course."
         )
 
+    is_trace_like = contract.mode == "algorithmic" and not contract.allow_thematic_reskin
+
     if forced_type == "FREE_RESPONSE":
         if contract.mode == "conceptual":
             chunks.append(
                 f"CONCEPTUAL: stay in {language_display(lang)} and CS ideas from the original; theme is only a hook. "
                 "Do not replace with unrelated domains. Do not put the full solution in variant_text or task."
             )
-            if not original_asks_for_code_submission(original_text or ""):
-                chunks.append(
-                    "The original asks for explanation or comparison only — do NOT turn it into a coding exercise "
-                    "(e.g. do not add 'write a function' or require implementation) unless the source explicitly "
-                    "asked for code."
-                )
-        elif contract.mode == "algorithmic" and not contract.allow_thematic_reskin:
+        if is_trace_like:
+            chunks.append(
+                "MULTI-STEP / STRUCTURE TASK: Stay in normal CS and data-structure vocabulary. "
+                "Do not wrap the problem in an unrelated real-world metaphor. "
+                "Preserve every requirement to show intermediate states, diagrams, or step-by-step structure "
+                "as clearly as in the original (same level of detail)."
+            )
+
+    if forced_type == "CODING":
+        if is_trace_like:
             chunks.append(
                 "MULTI-STEP / STRUCTURE TASK: Stay in normal CS and data-structure vocabulary. "
                 "Do not wrap the problem in an unrelated real-world metaphor. "
@@ -213,17 +217,24 @@ FORMAT CONSTRAINTS (MCQ):
 FORMAT CONSTRAINTS (TRUE/FALSE):
 - The statement must be clearly true or false with no ambiguity.
 - Keep the same truth value as the original if possible."""
-    else:
+    elif forced_type == "CODING":
         format_rules = f"""
-FORMAT CONSTRAINTS (FREE RESPONSE):
-- If the original asks to write a function, the variant must ask to write a function.
-- If the original asks to write a class, the variant must ask to write a class.
-- If the original asks for an explanation, the variant must ask for an explanation.
-- Preserve the same level of detail expected in the answer.
-- correct_answer MUST be non-empty.
-- If the question asks for code, correct_answer must be valid {ld} source (not prose about what it "should" do).
-- If the question asks for a prose explanation, correct_answer must be a concrete model answer (real sentences),
+FORMAT CONSTRAINTS (CODING — student submits source code):
+- The variant must still ask for real {ld} (or generic/C) source, not prose pretending to be code.
+- correct_answer MUST be non-empty, runnable-looking source that solves the stated task (not a rubric).
+- variant_text is the problem statement and any starter/snippet; put the full reference solution ONLY in correct_answer
+  unless the original intentionally shows partial code in the prompt.
+- Never use meta phrases like "The student should" in correct_answer.
+- Do not paste the entire solution into variant_text or task — keep the student-facing layer readable."""
+    else:
+        format_rules = """
+FORMAT CONSTRAINTS (FREE RESPONSE — prose / conceptual / traces):
+- If the original asks for an explanation or comparison, the variant must ask the same kind of thing.
+- If the original asks for a trace, step count, or written output of a program, preserve that shape.
+- correct_answer MUST be non-empty: concrete model prose or the exact trace/output the grader expects,
   not grading instructions (never start with "The student should" or "The correct answer should").
+- Do NOT turn a prose-only question into "write a function" unless the source explicitly asked for code —
+  that belongs in CODING, not FREE_RESPONSE.
 - Do not put the full model answer in variant_text or task; only correct_answer holds it."""
 
     return f"""You are creating a variant of a CS exam question. The variant should feel like a
@@ -308,7 +319,7 @@ OUTPUT JSON:
     "final_answer": "..."
 }}"""
 
-    conceptual = contract.mode == "conceptual"
+    conceptual = contract.mode == "conceptual" and forced_type != "CODING"
     code_only_invalid = (
         ""
         if conceptual

--- a/backend/app/variant_gen/question_contract.py
+++ b/backend/app/variant_gen/question_contract.py
@@ -353,12 +353,13 @@ class QuestionContract:
     allow_thematic_reskin: bool
     question_format: str
     expected_mcq_options: int
+    autograde_kind: str
     routing_source: str = "rules"
 
 
 def build_question_contract(text: str) -> QuestionContract:
     """
-    Rule-based stem router (language, mode, reskin, MCQ vs FR vs TF).
+    Rule-based stem router (language, mode, reskin, MCQ / FREE_RESPONSE / CODING / TRUE_FALSE).
 
     For optional LLM assist on format/language only, use ``route_stem`` in
     ``question_router.py`` (``QUESTION_ROUTER=llm``).
@@ -378,6 +379,7 @@ def build_question_contract(text: str) -> QuestionContract:
         allow_thematic_reskin=allow,
         question_format=qf,
         expected_mcq_options=emcq,
+        autograde_kind=qf,
         routing_source="rules",
     )
 

--- a/backend/app/variant_gen/question_inputs.py
+++ b/backend/app/variant_gen/question_inputs.py
@@ -1,9 +1,63 @@
 """Classify raw exam text: skip rules, vision, format, coarse algorithm tag."""
 
 import re
-from typing import Any, Dict
+from typing import Any, Dict, Optional
 
 from .config import _ALGORITHM_PATTERNS, openrouter_vision_enabled
+
+
+def original_asks_for_code_submission(original_text: Optional[str]) -> bool:
+    """Source stem asks the student to submit code (validators, prompts, vision skip)."""
+    t = (original_text or "").lower()
+    return any(
+        p in t
+        for p in (
+            "write a function",
+            "write a class",
+            "write pseudocode",
+            "recursive function",
+            "implement a function",
+            "define a function",
+            "complete the following program",
+            "complete the following code",
+            "write the following function",
+            "implement the following",
+        )
+    )
+
+
+def stem_routes_as_coding_format(text: str) -> bool:
+    """
+    Narrower than ``original_asks_for_code_submission``: use for ``question_format`` == CODING only.
+
+    Goal: autograder "code runner" path for real implementation (method/class/algorithm). Short
+    fill-in-the-blank or one-hole snippets stay FREE_RESPONSE even if they say "complete the code".
+    """
+    if not original_asks_for_code_submission(text):
+        return False
+    t = (text or "").lower()
+    # Typical one-line / blank style — prose FR autograder (rubric / partial credit).
+    if any(
+        p in t
+        for p in (
+            "fill in the blank",
+            "fill in the missing",
+            "fill-in the blank",
+            "fill in each",
+            "missing line",
+            "missing expression",
+            "replace ____",
+            "replace the ____",
+            "insert the missing",
+            "what expression should go",
+            "what should replace",
+        )
+    ):
+        return False
+    if "____" in t:
+        return False
+    # "Complete the following code" is often a whole method; keep CODING unless blank-style above matched.
+    return True
 
 
 def extract_algorithm(text: str) -> str:
@@ -38,7 +92,7 @@ def should_skip_question(text: str) -> bool:
 
 def _is_code_or_written_answer_question(text: str) -> bool:
     t = text.lower()
-    return any(
+    return original_asks_for_code_submission(text) or any(
         p in t
         for p in (
             "write a function",
@@ -113,12 +167,9 @@ def detect_format(text: str) -> str:
     if "true" in text_lower and "false" in text_lower:
         if len(text) < 200 or "select" in text_lower:
             return "TRUE_FALSE"
-    # Coding / written tasks often include numbered lines or lettered bullets; classify before MCQ heuristics.
-    if re.search(
-        r"\b(?:write\s+pseudocode|write\s+a\s+(?:function|class|method)|recursive\s+function)\b",
-        text_lower,
-    ):
-        return "FREE_RESPONSE"
+    # Substantial implementation (function/class/algorithm) → CODING autograder path, not prose FR.
+    if stem_routes_as_coding_format(text):
+        return "CODING"
     has_mcq = re.search(r"(?:^|\n|\s)(?:[A-E]|[1-5])[\.\)]\s+\w+", text)
     if has_mcq and _looks_like_numbered_written_subproblems(text):
         return "FREE_RESPONSE"
@@ -150,7 +201,8 @@ def count_options(text: str) -> int:
     # Tree/traversal dumps can look like dozens of fake options — cap and bail to 0.
     letter_opts = re.findall(r"(?:^|\n)\s*[A-E][\.\)]\s+\S", text)
     num_opts = re.findall(r"(?:^|\n)\s*[1-5][\.\)]\s+\S", text)
-    count = max(len(letter_opts), len(num_opts))
+    paren_opts = len(re.findall(r"(?:^|\n|\s)\(\s*([A-E])\s*\)", text, flags=re.IGNORECASE))
+    count = max(len(letter_opts), len(num_opts), paren_opts)
     if count < 2:
         return 0
     if count > 10:

--- a/backend/app/variant_gen/question_router.py
+++ b/backend/app/variant_gen/question_router.py
@@ -27,7 +27,7 @@ from .question_contract import (
     expected_mcq_options_for_stem,
 )
 
-_ALLOWED_FORMATS = frozenset({"MCQ", "FREE_RESPONSE", "TRUE_FALSE"})
+_ALLOWED_FORMATS = frozenset({"MCQ", "FREE_RESPONSE", "TRUE_FALSE", "CODING"})
 _ALLOWED_LANGS = frozenset({"python", "cpp", "java", "generic"})
 
 
@@ -59,6 +59,9 @@ def _normalize_format(val: Any) -> Optional[str]:
         "TRUEFALSE": "TRUE_FALSE",
         "T_F": "TRUE_FALSE",
         "TF": "TRUE_FALSE",
+        "CODING": "CODING",
+        "CODE": "CODING",
+        "IMPLEMENTATION": "CODING",
     }
     s = aliases.get(s, s)
     return s if s in _ALLOWED_FORMATS else None
@@ -76,13 +79,16 @@ def _llm_router_prompt(stem: str) -> str:
     return (
         "You classify an exam question stem for an automated variant generator.\n"
         "Return ONLY one JSON object (no markdown) with exactly these keys:\n"
-        '  "question_format": one of MCQ, FREE_RESPONSE, TRUE_FALSE\n'
+        '  "question_format": one of MCQ, FREE_RESPONSE, TRUE_FALSE, CODING\n'
         '  "language": one of python, cpp, java, generic\n'
         "Rules:\n"
         "- MCQ: student picks labeled options (A–E, 1–5, or (a)–(e)), including Roman-numeral clauses "
         "with lettered answer choices.\n"
         "- TRUE_FALSE: explicit true/false style.\n"
-        "- FREE_RESPONSE: written answer, traces, code to write, proofs, etc.\n"
+        "- FREE_RESPONSE: prose answers only — explain, compare, trace output, prove, runtime discussion; "
+        "not a full program submission.\n"
+        "- CODING: student must write or complete substantial source code (functions, classes, fill-in program, "
+        "implement following, etc.).\n"
         "- generic: stem is clearly C, Scheme, mixed course-specific code, or language is ambiguous; "
         "do not default to python unless the stem is actually Python.\n"
         "- java: AP-style or explicit Java syntax (class/interface, public static void, etc.).\n"
@@ -113,6 +119,7 @@ def _try_llm_route_stem(text: str) -> Optional[QuestionContract]:
         allow_thematic_reskin=base.allow_thematic_reskin,
         question_format=fmt,
         expected_mcq_options=expected_mcq_options_for_stem(text, fmt, lang),
+        autograde_kind=fmt,
         routing_source="llm",
     )
 
@@ -146,6 +153,7 @@ def telemetry_routing_line(question_id: str, contract: QuestionContract) -> str:
         "language": contract.language,
         "mode": contract.mode,
         "allow_thematic_reskin": contract.allow_thematic_reskin,
+        "autograde_kind": contract.autograde_kind,
     }
     return f"[variant_gen:telemetry] {json.dumps(payload, ensure_ascii=False)}"
 

--- a/backend/app/variant_gen/tests/test_stem_routing.py
+++ b/backend/app/variant_gen/tests/test_stem_routing.py
@@ -45,7 +45,59 @@ vector generateAllCouples(vector *boys, vector *girls) {
 2. Then scan characters left to right.
 """
         c = route_stem(stem)
+        self.assertEqual(c.question_format, "CODING")
+        self.assertEqual(c.autograde_kind, "CODING")
+
+    def test_autograde_kind_prose_free_response(self):
+        from variant_gen.question_router import route_stem
+
+        stem = """Explain why immutable strings can be used safely as dict keys.
+Give at least two sentences comparing tuples and lists."""
+        c = route_stem(stem)
         self.assertEqual(c.question_format, "FREE_RESPONSE")
+        self.assertEqual(c.autograde_kind, "FREE_RESPONSE")
+
+    def test_autograde_kind_mcq(self):
+        from variant_gen.question_router import route_stem
+
+        stem = """Which of the following is true?
+(a) foo (b) bar (c) baz (d) qux (e) none"""
+        c = route_stem(stem)
+        self.assertEqual(c.question_format, "MCQ")
+        self.assertEqual(c.autograde_kind, "MCQ")
+
+    def test_trace_output_is_free_response_not_coding(self):
+        from variant_gen.question_router import route_stem
+
+        stem = """What is the output when the following code is executed?
+public class Main {
+  public static void main(String[] args) {
+    System.out.println(3 + 4);
+  }
+}"""
+        c = route_stem(stem)
+        self.assertEqual(c.question_format, "FREE_RESPONSE")
+        self.assertEqual(c.autograde_kind, "FREE_RESPONSE")
+
+    def test_fill_in_blank_stays_free_response(self):
+        from variant_gen.question_router import route_stem
+
+        stem = """Fill in the missing expression. Complete the following code so the method returns the sum.
+
+    public int f(int[] a) {
+      return _______;
+    }"""
+        c = route_stem(stem)
+        self.assertEqual(c.question_format, "FREE_RESPONSE")
+        self.assertEqual(c.autograde_kind, "FREE_RESPONSE")
+
+    def test_complete_method_without_blank_is_coding(self):
+        from variant_gen.question_router import route_stem
+
+        stem = """Complete the following code. Implement the body of binarySearch so it returns the index
+or -1. You may not change the signature."""
+        c = route_stem(stem)
+        self.assertEqual(c.question_format, "CODING")
 
     def test_contract_has_question_format(self):
         from variant_gen.question_contract import build_question_contract

--- a/backend/app/variant_gen/variant_validation.py
+++ b/backend/app/variant_gen/variant_validation.py
@@ -12,6 +12,7 @@ from .question_contract import (
     free_response_cs_vocabulary_lost,
     language_display,
 )
+from .question_inputs import original_asks_for_code_submission
 
 
 def similarity_threshold_for_original(original_text: str) -> float:
@@ -58,25 +59,6 @@ _META_ANSWER_SNIPPETS = (
     "must be a function definition that",
     "solution should use",
 )
-
-
-def original_asks_for_code_submission(original_text: Optional[str]) -> bool:
-    t = (original_text or "").lower()
-    return any(
-        p in t
-        for p in (
-            "write a function",
-            "write a class",
-            "write pseudocode",
-            "recursive function",
-            "implement a function",
-            "define a function",
-            "complete the following program",
-            "complete the following code",
-            "write the following function",
-            "implement the following",
-        )
-    )
 
 
 def _variant_asks_for_code_submission(variant: Dict[str, Any]) -> bool:
@@ -268,13 +250,15 @@ def is_invalid_variant(
     if ca is None:
         ca = ""
 
-    if forced_type == "FREE_RESPONSE":
+    if forced_type in ("FREE_RESPONSE", "CODING"):
         fr_err = free_response_correct_answer_invalid(
             ca, variant, lang, contract, original_text
         )
         if fr_err:
             return fr_err
-        if free_response_cs_vocabulary_lost(original_text, variant, contract):
+        if forced_type == "FREE_RESPONSE" and free_response_cs_vocabulary_lost(
+            original_text, variant, contract
+        ):
             return "conceptual FR drifted off-topic (keep CS terms from the original, not a novelty theme)"
         ca_str = ca if isinstance(ca, str) else str(ca)
         if _variant_code_blob_heuristic(vt_raw, lang):


### PR DESCRIPTION
Add proper question coding type for variant generation instead of lumping it in with "free response" changed question routing so that it can properly detect coding questions and tag them as coding instead of free response.