### PR TITLE
[FRONTEND] Short answer question allows in-line responses

### DIFF
--- a/frontend/src/components/QuestionCard.jsx
+++ b/frontend/src/components/QuestionCard.jsx
@@ -816,64 +816,172 @@ export default function QuestionCard({
         }
 
         // For Free Response and Short Answer: show rubric parts
-        if ((isFR || isShortAnswer) && answerChoices.length > 0 && typeof answerChoices[0] === 'object') {
-          const getPartMaxPoints = (p) => {
-            const levels = p.rubric_levels || [];
-            if (levels.length > 0) return Math.max(...levels.map(l => parseInt(l.points) || 0));
-            return parseInt(p.points) || 0;
-          };
-          const totalPoints = answerChoices.reduce((sum, p) => sum + getPartMaxPoints(p), 0);
+        // For Short Answer: show inline input + valid answers (new format)
+if (isShortAnswer) {
+  let saConfig = null;
+  if (
+    answerChoices &&
+    !Array.isArray(answerChoices) &&
+    typeof answerChoices === 'object' &&
+    answerChoices.valid_answers
+  ) {
+    saConfig = answerChoices;
+  }
+
+  const restriction = saConfig?.input_restriction || 'any';
+  const inputType = restriction === 'numbers' ? 'number' : 'text';
+
+  return (
+    <div style={{ marginBottom: compact ? '0.75rem' : '1rem' }}>
+      {/* Inline answer input */}
+      <div style={{ marginBottom: '0.75rem' }}>
+        <label style={{
+          display: 'block',
+          fontSize: '0.8rem',
+          fontWeight: 700,
+          color: dashboardPalette.muted,
+          marginBottom: '0.4rem',
+          textTransform: 'uppercase',
+          letterSpacing: '0.04em'
+        }}>
+          Your answer
+          {restriction !== 'any' && (
+            <span style={{
+              marginLeft: '0.5rem',
+              fontSize: '0.7rem',
+              fontWeight: 600,
+              background: dashboardPalette.navyLight,
+              color: dashboardPalette.navy,
+              padding: '1px 6px',
+              borderRadius: '4px',
+              textTransform: 'none',
+              letterSpacing: 0
+            }}>
+              {restriction === 'numbers' ? 'numbers only' : 'letters only'}
+            </span>
+          )}
+        </label>
+        <input
+          type={inputType}
+          placeholder="Type your answer here…"
+          style={{
+            width: '100%',
+            maxWidth: '360px',
+            padding: '0.5rem 0.75rem',
+            borderRadius: '8px',
+            border: `1px solid ${dashboardPalette.border}`,
+            fontSize: '0.95rem',
+            color: dashboardPalette.text,
+            background: dashboardPalette.white,
+            boxSizing: 'border-box',
+            outline: 'none',
+          }}
+        />
+      </div>
+
+      {/* Valid answers — instructor view */}
+      {saConfig?.valid_answers?.length > 0 && (
+        <div style={{
+          padding: '0.65rem 0.75rem',
+          background: dashboardPalette.surface,
+          border: `1px solid ${dashboardPalette.border}`,
+          borderRadius: '8px',
+          fontSize: '0.82rem'
+        }}>
+          <div style={{ fontWeight: 700, color: dashboardPalette.navy, marginBottom: '0.4rem' }}>
+            Valid answers:
+          </div>
+          <div style={{ display: 'flex', flexWrap: 'wrap', gap: '0.4rem' }}>
+            {saConfig.valid_answers.map((ans, i) => (
+              <span
+                key={i}
+                style={{
+                  background: dashboardPalette.navyLight,
+                  color: dashboardPalette.navy,
+                  padding: '0.2rem 0.6rem',
+                  borderRadius: '6px',
+                  border: `1px solid ${dashboardPalette.border}`,
+                  fontWeight: 600,
+                  fontSize: '0.8rem',
+                }}
+              >
+                {ans.value}
+                {!ans.case_sensitive && (
+                  <span style={{ opacity: 0.6, fontWeight: 400, marginLeft: '4px' }}>(any case)</span>
+                )}
+              </span>
+            ))}
+          </div>
+          {saConfig.points != null && (
+            <div style={{ marginTop: '0.5rem', color: dashboardPalette.muted, fontSize: '0.78rem' }}>
+              {saConfig.points} point{saConfig.points !== 1 ? 's' : ''} for a correct match
+            </div>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}
+
+// For Short Answer: show inline input + valid answers (new format)
+if (isFR && answerChoices.length > 0 && typeof answerChoices[0] === 'object') {
+  const getPartMaxPoints = (p) => {
+    const levels = p.rubric_levels || [];
+    if (levels.length > 0) return Math.max(...levels.map(l => parseInt(l.points) || 0));
+    return parseInt(p.points) || 0;
+  };
+  const totalPoints = answerChoices.reduce((sum, p) => sum + getPartMaxPoints(p), 0);
+  return (
+    <div style={{ marginBottom: compact ? '0.75rem' : '1rem' }}>
+      <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', marginBottom: '0.5rem' }}>
+        <div style={{ fontSize: '0.875rem', fontWeight: '700', color: dashboardPalette.navy }}>
+          Parts & Rubric ({answerChoices.length} parts):
+        </div>
+        <span style={{ fontSize: '0.75rem', color: dashboardPalette.muted, fontWeight: '600' }}>
+          {totalPoints} pts total
+        </span>
+      </div>
+      <div style={{ display: 'flex', flexDirection: 'column', gap: '0.5rem' }}>
+        {answerChoices.map((part, index) => {
+          const levels = part.rubric_levels || [];
+          const maxPts = levels.length > 0 ? Math.max(...levels.map(l => parseInt(l.points) || 0)) : (parseInt(part.points) || 0);
           return (
-            <div style={{ marginBottom: compact ? '0.75rem' : '1rem' }}>
-              <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', marginBottom: '0.5rem' }}>
-                <div style={{ fontSize: '0.875rem', fontWeight: '700', color: dashboardPalette.navy }}>
-                  Parts & Rubric ({answerChoices.length} parts):
-                </div>
-                <span style={{ fontSize: '0.75rem', color: dashboardPalette.muted, fontWeight: '600' }}>
-                  {totalPoints} pts total
+            <div
+              key={index}
+              style={{
+                padding: '0.75rem',
+                borderRadius: '8px',
+                border: `1px solid ${dashboardPalette.border}`,
+                background: dashboardPalette.surface,
+                fontSize: '0.875rem'
+              }}
+            >
+              <div style={{ display: 'flex', justifyContent: 'space-between', marginBottom: '0.35rem' }}>
+                <span style={{ fontWeight: '600', color: dashboardPalette.text }}>
+                  {part.part_label || `Part ${index + 1}`}
+                </span>
+                <span style={{ background: dashboardPalette.white, color: dashboardPalette.navy, padding: '2px 8px', borderRadius: '6px', border: `1px solid ${dashboardPalette.border}`, fontSize: '0.75rem', fontWeight: '600' }}>
+                  {maxPts} pts max
                 </span>
               </div>
-              <div style={{ display: 'flex', flexDirection: 'column', gap: '0.5rem' }}>
-                {answerChoices.map((part, index) => {
-                  const levels = part.rubric_levels || [];
-                  const maxPts = levels.length > 0 ? Math.max(...levels.map(l => parseInt(l.points) || 0)) : (parseInt(part.points) || 0);
-                  return (
-                    <div
-                      key={index}
-                      style={{
-                        padding: '0.75rem',
-                        borderRadius: '8px',
-                        border: `1px solid ${dashboardPalette.border}`,
-                        background: dashboardPalette.surface,
-                        fontSize: '0.875rem'
-                      }}
-                    >
-                      <div style={{ display: 'flex', justifyContent: 'space-between', marginBottom: '0.35rem' }}>
-                        <span style={{ fontWeight: '600', color: dashboardPalette.text }}>
-                          {part.part_label || `Part ${index + 1}`}
-                        </span>
-                        <span style={{ background: dashboardPalette.white, color: dashboardPalette.navy, padding: '2px 8px', borderRadius: '6px', border: `1px solid ${dashboardPalette.border}`, fontSize: '0.75rem', fontWeight: '600' }}>
-                          {maxPts} pts max
-                        </span>
-                      </div>
-                      {levels.length > 0 ? (
-                        <div style={{ display: 'flex', flexDirection: 'column', gap: '0.2rem' }}>
-                          {levels.map((l, i) => (
-                            <div key={i} style={{ fontSize: '0.8rem', color: dashboardPalette.muted, lineHeight: 1.3 }}>
-                              <span style={{ fontWeight: '600', color: dashboardPalette.navy }}>+{l.points || 0}:</span> {l.criteria || '—'}
-                            </div>
-                          ))}
-                        </div>
-                      ) : part.rubric_text && (
-                        <p style={{ margin: 0, color: dashboardPalette.muted, fontSize: '0.8rem', lineHeight: 1.4 }}>{part.rubric_text}</p>
-                      )}
+              {levels.length > 0 ? (
+                <div style={{ display: 'flex', flexDirection: 'column', gap: '0.2rem' }}>
+                  {levels.map((l, i) => (
+                    <div key={i} style={{ fontSize: '0.8rem', color: dashboardPalette.muted, lineHeight: 1.3 }}>
+                      <span style={{ fontWeight: '600', color: dashboardPalette.navy }}>+{l.points || 0}:</span> {l.criteria || '—'}
                     </div>
-                  );
-                })}
-              </div>
+                  ))}
+                </div>
+              ) : part.rubric_text && (
+                <p style={{ margin: 0, color: dashboardPalette.muted, fontSize: '0.8rem', lineHeight: 1.4 }}>{part.rubric_text}</p>
+              )}
             </div>
           );
-        }
+        })}
+      </div>
+    </div>
+  );
+}
 
         if (isCoding) {
           const codingConfig = getQuestionCodingConfig(question);

--- a/frontend/src/components/StudentPreview.jsx
+++ b/frontend/src/components/StudentPreview.jsx
@@ -641,13 +641,13 @@ export default function StudentPreview({
   };
   const wrapperStyle = inline
     ? {
-        background: dashboardPalette.surface,
-        height: '100%',
-        overflowY: 'auto',
-        overscrollBehavior: 'contain',
-        WebkitOverflowScrolling: 'touch',
-        touchAction: 'pan-y'
-      }
+      background: dashboardPalette.surface,
+      height: '100%',
+      overflowY: 'auto',
+      overscrollBehavior: 'contain',
+      WebkitOverflowScrolling: 'touch',
+      touchAction: 'pan-y'
+    }
     : styles.overlay;
   const containerStyle = inline
     ? { ...styles.container, maxWidth: '100%', padding: '1rem' }
@@ -694,13 +694,13 @@ export default function StudentPreview({
 
   const answerChoices = getAnswerChoices(currentQuestion);
   const questionType = currentQuestion.question_type?.toLowerCase();
-  const isMCQ = questionType === 'mcq' || questionType === 'true_false' || 
+  const isMCQ = questionType === 'mcq' || questionType === 'true_false' ||
     (answerChoices.length > 0 && typeof answerChoices[0] === 'string');
   const isFreeResponse = questionType === 'fr';
   const isShortAnswer = questionType === 'short_answer';
   const isCoding = isCodingQuestion(questionType);
   const codingConfig = isCoding ? getCodingConfig(currentQuestion) : null;
-  const rubricParts = (isFreeResponse || isShortAnswer) && answerChoices.length > 0 && typeof answerChoices[0] === 'object' 
+  const rubricParts = isFreeResponse && Array.isArray(answerChoices) && answerChoices.length > 0 && typeof answerChoices[0] === 'object'
     ? answerChoices : [];
   const selectedAnswer = answers[currentQuestion.id];
   const selectedCodingAnswer = isCoding ? getCodingAnswerPayload(currentQuestion.id) : { language: 'cpp', source_code: '' };
@@ -791,7 +791,7 @@ export default function StudentPreview({
           </div>
         )}
 
-        {/* Header with Progress */} 
+        {/* Header with Progress */}
         {showHeader && (
           <div style={styles.header}>
             <div style={styles.titleRow}>
@@ -804,7 +804,7 @@ export default function StudentPreview({
                 {assignmentType}
               </span>
             </div>
-            
+
             <div style={styles.progressSection}>
               <div style={styles.progressInfo}>
                 <span>Question {currentIndex + 1} of {totalQuestions}</span>
@@ -845,7 +845,7 @@ export default function StudentPreview({
         {/* Question Card */}
         <div style={styles.questionCard}>
           {showHeader && <div style={styles.questionNumber}>Question {currentIndex + 1}</div>}
-          
+
           {currentQuestion.title && (
             <div style={styles.questionTitle}>{currentQuestion.title}</div>
           )}
@@ -856,8 +856,8 @@ export default function StudentPreview({
               remarkPlugins={[remarkGfm, remarkMath]}
               rehypePlugins={[rehypeKatex]}
               components={{
-                p: ({children}) => <p style={{ margin: '0 0 0.75rem 0' }}>{children}</p>,
-                code: ({node, inline, className, children, ...props}) => {
+                p: ({ children }) => <p style={{ margin: '0 0 0.75rem 0' }}>{children}</p>,
+                code: ({ node, inline, className, children, ...props }) => {
                   return inline ? (
                     <code style={{
                       background: '#e9ecef',
@@ -905,15 +905,15 @@ export default function StudentPreview({
                     const isSelected = selectedAnswer === choice;
                     const isCorrect = choice === currentQuestion.correct_answer;
                     const showResult = !isPreviewMode && (submitted || showCorrectAnswers) && isSelected;
-                    
+
                     let buttonStyle = { ...styles.choiceButton };
                     let indicatorStyle = { ...styles.choiceIndicator };
-                    
+
                     if (isSelected) {
                       buttonStyle = { ...buttonStyle, ...styles.choiceButtonSelected };
                       indicatorStyle = { ...indicatorStyle, ...styles.choiceIndicatorSelected };
                     }
-                    
+
                     if (showResult && showCorrectAnswers) {
                       if (isCorrect) {
                         buttonStyle = { ...buttonStyle, ...styles.choiceButtonCorrect };
@@ -958,55 +958,109 @@ export default function StudentPreview({
               </>
             )}
 
-            {isShortAnswer && rubricParts.length > 0 && (
-              <>
-                <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', marginBottom: '1rem' }}>
-                  <div style={styles.answerLabel}>Your answer:</div>
-                  {isPreviewMode && (
-                    <span style={{ fontSize: '0.875rem', color: dashboardPalette.muted }}>
-                      {rubricParts.reduce((sum, p) => {
-                        const levels = p.rubric_levels || [];
-                        const maxPts = levels.length > 0 ? Math.max(...levels.map(l => parseInt(l.points) || 0)) : (parseInt(p.points) || 0);
-                        return sum + maxPts;
-                      }, 0)} points total
-                    </span>
-                  )}
-                </div>
-                {isPreviewMode && (
-                  <div style={{ marginBottom: '1rem' }}>
-                    <div style={{ fontSize: '0.75rem', color: dashboardPalette.muted, marginBottom: '0.5rem', fontWeight: '600' }}>
-                      Grading rubric (visible to instructors only):
-                    </div>
-                    <div style={{ display: 'flex', flexDirection: 'column', gap: '0.5rem', marginBottom: '1rem' }}>
-                      {rubricParts.flatMap((part, partIdx) => {
-                        const levels = part.rubric_levels || [];
-                        if (levels.length > 0) {
-                          return levels.map((l, i) => (
-                            <div key={`${partIdx}-${i}`} style={{ fontSize: '0.8rem', color: dashboardPalette.text, padding: '0.5rem', background: dashboardPalette.surface, borderRadius: '8px', border: `1px solid ${dashboardPalette.border}` }}>
-                              <span style={{ fontWeight: '600' }}>+{l.points || 0} pts:</span> {l.criteria || '—'}
-                            </div>
-                          ));
-                        }
-                        return (
-                          <div key={partIdx} style={{ fontSize: '0.8rem', color: dashboardPalette.text, padding: '0.5rem', background: dashboardPalette.surface, borderRadius: '8px', border: `1px solid ${dashboardPalette.border}` }}>
-                            <span style={{ fontWeight: '600' }}>+{part.points || 0} pts:</span> {part.rubric_text || '—'}
-                          </div>
-                        );
-                      })}
-                    </div>
+            {isShortAnswer && (() => {
+              // Parse short answer config (new format: object with valid_answers)
+              // vs old format (array of rubric parts)
+              let saConfig = null;
+              if (
+                answerChoices &&
+                !Array.isArray(answerChoices) &&
+                typeof answerChoices === 'object' &&
+                answerChoices.valid_answers
+              ) {
+                saConfig = answerChoices;
+              }
+
+              const restriction = saConfig?.input_restriction || 'any';
+              const inputType = restriction === 'numbers' ? 'number' : 'text';
+              const inputPattern = restriction === 'letters' ? '[A-Za-z]*' : undefined;
+
+              return (
+                <>
+                  <div style={styles.answerLabel}>
+                    Your answer:
+                    {restriction !== 'any' && (
+                      <span style={{
+                        marginLeft: '0.5rem',
+                        fontSize: '0.75rem',
+                        fontWeight: 600,
+                        background: dashboardPalette.navyLight,
+                        color: dashboardPalette.navy,
+                        padding: '1px 6px',
+                        borderRadius: '4px',
+                      }}>
+                        {restriction === 'numbers' ? 'numbers only' : 'letters only'}
+                      </span>
+                    )}
                   </div>
-                )}
-                <textarea
-                  style={styles.textArea}
-                  placeholder="Enter your short answer..."
-                  value={selectedAnswer || ''}
-                  onChange={(e) => handleTextAnswer(currentQuestion.id, e.target.value)}
-                  disabled={isReadOnly}
-                  onFocus={(e) => e.target.style.borderColor = dashboardPalette.navy}
-                  onBlur={(e) => e.target.style.borderColor = dashboardPalette.border}
-                />
-              </>
-            )}
+
+                  <input
+                    type={inputType}
+                    pattern={inputPattern}
+                    placeholder="Type your answer here…"
+                    value={selectedAnswer || ''}
+                    onChange={(e) => handleTextAnswer(currentQuestion.id, e.target.value)}
+                    disabled={isReadOnly}
+                    onFocus={(e) => e.target.style.borderColor = dashboardPalette.navy}
+                    onBlur={(e) => e.target.style.borderColor = dashboardPalette.border}
+                    style={{
+                      width: '100%',
+                      maxWidth: '420px',
+                      padding: '0.65rem 0.85rem',
+                      borderRadius: '8px',
+                      border: `1px solid ${dashboardPalette.border}`,
+                      fontSize: '0.95rem',
+                      color: dashboardPalette.text,
+                      background: isReadOnly ? dashboardPalette.surface : dashboardPalette.white,
+                      boxSizing: 'border-box',
+                      outline: 'none',
+                    }}
+                  />
+
+                  {/* Valid answers — shown in preview/instructor mode only */}
+                  {isPreviewMode && saConfig?.valid_answers?.length > 0 && (
+                    <div style={{
+                      marginTop: '0.85rem',
+                      padding: '0.65rem 0.75rem',
+                      background: dashboardPalette.surface,
+                      border: `1px solid ${dashboardPalette.border}`,
+                      borderRadius: '8px',
+                      fontSize: '0.82rem'
+                    }}>
+                      <div style={{ fontWeight: 700, color: dashboardPalette.navy, marginBottom: '0.4rem' }}>
+                        Valid answers (instructor view):
+                      </div>
+                      <div style={{ display: 'flex', flexWrap: 'wrap', gap: '0.4rem' }}>
+                        {saConfig.valid_answers.map((ans, i) => (
+                          <span
+                            key={i}
+                            style={{
+                              background: dashboardPalette.navyLight,
+                              color: dashboardPalette.navy,
+                              padding: '0.2rem 0.6rem',
+                              borderRadius: '6px',
+                              border: `1px solid ${dashboardPalette.border}`,
+                              fontWeight: 600,
+                              fontSize: '0.8rem',
+                            }}
+                          >
+                            {ans.value}
+                            {!ans.case_sensitive && (
+                              <span style={{ opacity: 0.6, fontWeight: 400, marginLeft: '4px' }}>(any case)</span>
+                            )}
+                          </span>
+                        ))}
+                      </div>
+                      {saConfig.points != null && (
+                        <div style={{ marginTop: '0.5rem', color: dashboardPalette.muted, fontSize: '0.78rem' }}>
+                          {saConfig.points} point{saConfig.points !== 1 ? 's' : ''} for a correct match
+                        </div>
+                      )}
+                    </div>
+                  )}
+                </>
+              );
+            })()}
 
             {isFreeResponse && rubricParts.length > 0 && (
               <>
@@ -1028,9 +1082,9 @@ export default function StudentPreview({
                   const maxPts = levels.length > 0 ? Math.max(...levels.map(l => parseInt(l.points) || 0)) : (parseInt(part.points) || 0);
                   return (
                     <div key={idx} style={{ marginBottom: '1.5rem' }}>
-                      <div style={{ 
-                        display: 'flex', 
-                        justifyContent: 'space-between', 
+                      <div style={{
+                        display: 'flex',
+                        justifyContent: 'space-between',
                         alignItems: 'center',
                         marginBottom: '0.5rem'
                       }}>
@@ -1038,10 +1092,10 @@ export default function StudentPreview({
                           {part.part_label || `Part ${String.fromCharCode(65 + idx)}`}
                         </span>
                         {isPreviewMode && (
-                          <span style={{ 
-                            background: '#e0f2fe', 
-                            color: '#0369a1', 
-                            padding: '4px 10px', 
+                          <span style={{
+                            background: '#e0f2fe',
+                            color: '#0369a1',
+                            padding: '4px 10px',
                             borderRadius: '4px',
                             fontSize: '0.75rem',
                             fontWeight: '600'
@@ -1193,7 +1247,8 @@ export default function StudentPreview({
               </>
             )}
 
-            {(isFreeResponse || isShortAnswer) && rubricParts.length === 0 && (
+            {isFreeResponse && rubricParts.length === 0 && (
+
               <>
                 <div style={styles.answerLabel}>Your response:</div>
                 <textarea
@@ -1254,13 +1309,13 @@ export default function StudentPreview({
             <div style={{ display: 'flex', gap: '1rem' }}>
               {showFinishPreviewButton && (
                 <button
-                style={styles.submitButton}
-                onClick={onClose}
-                onMouseEnter={(e) => e.currentTarget.style.background = dashboardPalette.navyMid}
-                onMouseLeave={(e) => e.currentTarget.style.background = dashboardPalette.navy}
-              >
-                Finish Preview
-              </button>
+                  style={styles.submitButton}
+                  onClick={onClose}
+                  onMouseEnter={(e) => e.currentTarget.style.background = dashboardPalette.navyMid}
+                  onMouseLeave={(e) => e.currentTarget.style.background = dashboardPalette.navy}
+                >
+                  Finish Preview
+                </button>
               )}
             </div>
 

--- a/frontend/src/pages/CreateQuestion.jsx
+++ b/frontend/src/pages/CreateQuestion.jsx
@@ -12,6 +12,11 @@ import { createDefaultCodingConfig, normalizeEditableCodingConfig, sanitizeCodin
 import { CourseDashboardBackButton, dashboardPalette } from '../components/CourseDashboardUI';
 import { getFromHash, navigateBackWithFallback } from '../utils/navigation';
 
+const DEFAULT_SHORT_ANSWER_CONFIG = {
+  valid_answers: [],
+  input_restriction: 'any',
+  points: 1,
+};
 export default function CreateQuestion() {
   const { user } = useAuth();
   const fromHash = getFromHash();
@@ -29,9 +34,10 @@ export default function CreateQuestion() {
     correct_answer: '',
     is_verified: true,
     rubric_parts: [{ part_label: 'Part A', rubric_levels: [{ points: 6, criteria: '' }, { points: 3, criteria: '' }, { points: 0, criteria: '' }] }],
-    short_answer_expected: '',
+    short_answer_config: { ...DEFAULT_SHORT_ANSWER_CONFIG },
     coding_config: createDefaultCodingConfig(),
   });
+  
   const [imageFile, setImageFile] = useState(null);
   const [imagePreview, setImagePreview] = useState(null);
   const [imageInputRef, setImageInputRef] = useState(null);
@@ -42,6 +48,7 @@ export default function CreateQuestion() {
   const [isSplitView, setIsSplitView] = useState(false);
   const [showStudentPreview, setShowStudentPreview] = useState(false);
   const [profileSchool, setProfileSchool] = useState('');
+
 
   // Auto-save to LocalStorage whenever formData changes
   useEffect(() => {
@@ -197,8 +204,7 @@ export default function CreateQuestion() {
       }
       // When switching to Short Answer, collapse to single part (no multiple parts for short answer)
       if (name === 'question_type' && value === 'short_answer') {
-        const firstPart = next.rubric_parts?.[0] || { part_label: 'Part A', rubric_levels: [{ points: 6, criteria: '' }, { points: 3, criteria: '' }, { points: 0, criteria: '' }] };
-        next.rubric_parts = [firstPart];
+        next.short_answer_config = { ...DEFAULT_SHORT_ANSWER_CONFIG };
       }
       if (name === 'question_type' && value === 'coding') {
         next.coding_config = normalizeEditableCodingConfig(next.coding_config);
@@ -312,6 +318,38 @@ export default function CreateQuestion() {
     return levels.length > 0 ? Math.max(...levels.map(l => parseInt(l.points) || 0)) : 0;
   };
 
+  //helper functions for short answer
+  const updateShortAnswerConfig = (patch) => {
+    setFormData(prev => ({
+      ...prev,
+      short_answer_config: { ...prev.short_answer_config, ...patch }
+    }));
+  };
+
+  const addValidAnswer = () => {
+    setFormData(prev => ({
+      ...prev,
+      short_answer_config: {
+        ...prev.short_answer_config,
+        valid_answers: [
+          ...prev.short_answer_config.valid_answers,
+          { value: '', case_sensitive: false }
+        ]
+      }
+    }));
+  };
+
+  const updateValidAnswer = (index, patch) => {
+    const updated = [...formData.short_answer_config.valid_answers];
+    updated[index] = { ...updated[index], ...patch };
+    updateShortAnswerConfig({ valid_answers: updated });
+  };
+
+  const removeValidAnswer = (index) => {
+    const updated = formData.short_answer_config.valid_answers.filter((_, i) => i !== index);
+    updateShortAnswerConfig({ valid_answers: updated });
+  };
+
   // Check if question type needs answer choices
   const needsAnswerChoices = () => {
     return ['mcq', 'true_false'].includes(formData.question_type);
@@ -337,16 +375,20 @@ export default function CreateQuestion() {
   };
 
   // Check if question type needs rubric (both FR and Short Answer)
-  const needsRubric = () => {
-    return formData.question_type === 'fr' || formData.question_type === 'short_answer';
-  };
+  const needsRubric = () => formData.question_type === 'fr';
+
 
   const getStudentPreviewQuestion = () => {
-    const answerChoices = isCoding()
-      ? sanitizeCodingConfigForSave(formData.coding_config)
-      : needsAnswerChoices()
-        ? (isTrueFalse() ? ['True', 'False'] : formData.answer_choices.filter(choice => choice.trim()))
-        : formData.rubric_parts;
+    let answerChoices;
+    if (isCoding()) {
+      answerChoices = sanitizeCodingConfigForSave(formData.coding_config);
+    } else if (needsAnswerChoices()) {
+      answerChoices = isTrueFalse() ? ['True', 'False'] : formData.answer_choices.filter(c => c.trim());
+    } else if (isShortAnswer()) {
+      answerChoices = formData.short_answer_config;
+    } else {
+      answerChoices = formData.rubric_parts;
+    }
 
     return {
       id: 'live-preview',
@@ -452,6 +494,14 @@ export default function CreateQuestion() {
         return;
       }
     }
+    if (isShortAnswer()) {
+      const filledAnswers = formData.short_answer_config.valid_answers.filter(a => a.value.trim());
+      if (filledAnswers.length === 0) {
+        setError('Add at least one valid answer for the short answer question');
+        setLoading(false);
+        return;
+      }
+    }
 
     if (isCoding()) {
       const codingError = getCodingAuthoringError(formData.coding_config);
@@ -498,8 +548,14 @@ export default function CreateQuestion() {
         const validAnswers = isTrueFalse() ? ['True', 'False'] : formData.answer_choices.filter(a => a.trim());
         answerChoicesData = JSON.stringify(validAnswers);
         correctAnswerData = formData.correct_answer;
+      } else if (isShortAnswer()) {
+        const cleanConfig = {
+          ...formData.short_answer_config,
+          valid_answers: formData.short_answer_config.valid_answers.filter(a => a.value.trim()),
+        };
+        answerChoicesData = JSON.stringify(cleanConfig);
+        correctAnswerData = 'short_answer';
       } else if (needsRubric()) {
-        // Store rubric parts for both free response and short answer
         answerChoicesData = JSON.stringify(formData.rubric_parts);
         correctAnswerData = 'rubric';
       }
@@ -539,7 +595,7 @@ export default function CreateQuestion() {
         answer_choices: ['', '', '', ''],
         correct_answer: '',
         rubric_parts: [{ part_label: 'Part A', rubric_levels: [{ points: 6, criteria: '' }, { points: 3, criteria: '' }, { points: 0, criteria: '' }] }],
-        short_answer_expected: '',
+        short_answer_config: { ...DEFAULT_SHORT_ANSWER_CONFIG },
         coding_config: createDefaultCodingConfig(),
       });
       setImageFile(null);
@@ -552,6 +608,181 @@ export default function CreateQuestion() {
     } finally {
       setLoading(false);
     }
+  };
+
+  const renderShortAnswerCard = () => {
+    const { valid_answers, input_restriction, points } = formData.short_answer_config;
+    const inputTypeForAnswerField = input_restriction === 'numbers' ? 'number' : 'text';
+
+    return (
+      <div style={styles.card}>
+        <label style={styles.label}>Short Answer Setup</label>
+
+        {/* Input restriction toggle */}
+        <div style={{ marginBottom: '20px' }}>
+          <label style={{ ...styles.label, fontSize: '12px', textTransform: 'uppercase', letterSpacing: '0.04em', marginBottom: '10px' }}>
+            Restrict student input type
+          </label>
+          <div style={{ display: 'flex', gap: '8px', flexWrap: 'wrap' }}>
+            {[
+              { value: 'any', label: 'Any text' },
+              { value: 'numbers', label: 'Numbers only' },
+              { value: 'letters', label: 'Letters only' },
+            ].map((opt) => {
+              const isActive = input_restriction === opt.value;
+              return (
+                <button
+                  key={opt.value}
+                  type="button"
+                  onClick={() => updateShortAnswerConfig({ input_restriction: opt.value })}
+                  style={{
+                    padding: '6px 16px',
+                    borderRadius: '99px',
+                    fontSize: '13px',
+                    fontWeight: 600,
+                    cursor: 'pointer',
+                    border: isActive
+                      ? `2px solid ${dashboardPalette.navy}`
+                      : `1px solid ${dashboardPalette.border}`,
+                    background: isActive ? dashboardPalette.navyLight : dashboardPalette.white,
+                    color: isActive ? dashboardPalette.navy : dashboardPalette.text,
+                  }}
+                >
+                  {opt.label}
+                </button>
+              );
+            })}
+          </div>
+        </div>
+
+        {/* Valid answers list */}
+        <div style={{ marginBottom: '20px' }}>
+          <div style={{ display: 'flex', alignItems: 'baseline', gap: '8px', marginBottom: '10px' }}>
+            <label style={{ ...styles.label, margin: 0 }}>Valid answers</label>
+            <span style={{ fontSize: '12px', color: dashboardPalette.muted }}>
+              Students must match one of these to receive credit
+            </span>
+          </div>
+
+          {valid_answers.length === 0 && (
+            <div style={{
+              padding: '16px',
+              background: dashboardPalette.surface,
+              border: `1px dashed ${dashboardPalette.border}`,
+              borderRadius: '8px',
+              textAlign: 'center',
+              fontSize: '13px',
+              color: dashboardPalette.muted,
+              marginBottom: '10px'
+            }}>
+              No valid answers added yet. Add at least one.
+            </div>
+          )}
+
+          {valid_answers.map((ans, idx) => (
+            <div
+              key={idx}
+              style={{
+                display: 'flex',
+                alignItems: 'center',
+                gap: '10px',
+                marginBottom: '8px',
+                padding: '10px 12px',
+                background: dashboardPalette.surface,
+                border: `1px solid ${dashboardPalette.border}`,
+                borderRadius: '8px',
+              }}
+            >
+              <input
+                type={inputTypeForAnswerField}
+                value={ans.value}
+                placeholder={
+                  input_restriction === 'numbers' ? 'e.g. 42'
+                    : input_restriction === 'letters' ? 'e.g. oxygen'
+                      : 'e.g. O(log n)'
+                }
+                onChange={(e) => updateValidAnswer(idx, { value: e.target.value })}
+                style={{ ...styles.input, flex: 1 }}
+              />
+
+              {input_restriction !== 'numbers' && (
+                <label style={{
+                  display: 'flex',
+                  alignItems: 'center',
+                  gap: '5px',
+                  fontSize: '13px',
+                  color: dashboardPalette.muted,
+                  whiteSpace: 'nowrap',
+                  cursor: 'pointer',
+                  flexShrink: 0,
+                }}>
+                  <input
+                    type="checkbox"
+                    checked={!ans.case_sensitive}
+                    onChange={(e) => updateValidAnswer(idx, { case_sensitive: !e.target.checked })}
+                    style={{ width: '15px', height: '15px', cursor: 'pointer' }}
+                  />
+                  Case-insensitive
+                </label>
+              )}
+
+              <button
+                type="button"
+                onClick={() => removeValidAnswer(idx)}
+                style={{
+                  border: 'none',
+                  background: 'none',
+                  color: dashboardPalette.muted,
+                  cursor: 'pointer',
+                  fontSize: '20px',
+                  lineHeight: 1,
+                  padding: '0 2px',
+                  flexShrink: 0,
+                }}
+                aria-label="Remove answer"
+              >
+                ×
+              </button>
+            </div>
+          ))}
+
+          <button
+            type="button"
+            onClick={addValidAnswer}
+            style={{
+              ...styles.secondaryBtn,
+              borderStyle: 'dashed',
+              padding: '8px 16px',
+              fontSize: '13px',
+              height: 'auto',
+              marginTop: '4px',
+            }}
+          >
+            + Add valid answer
+          </button>
+        </div>
+
+        {/* Points */}
+        <div style={{
+          display: 'flex',
+          alignItems: 'center',
+          gap: '12px',
+          paddingTop: '16px',
+          borderTop: `1px solid ${dashboardPalette.border}`,
+        }}>
+          <label style={{ ...styles.label, margin: 0, whiteSpace: 'nowrap' }}>
+            Points for correct match:
+          </label>
+          <input
+            type="number"
+            min="0"
+            value={points}
+            onChange={(e) => updateShortAnswerConfig({ points: parseInt(e.target.value) || 0 })}
+            style={{ ...styles.input, width: '80px' }}
+          />
+        </div>
+      </div>
+    );
   };
 
   const renderMetadataCard = () => (
@@ -696,29 +927,31 @@ export default function CreateQuestion() {
                     <button
                       type="button"
                       onClick={() => setViewMode('edit')}
-                      style={{ ...
-                        styles.secondaryBtn, 
-                        padding: '4px 12px', 
-                        border: 'none', 
+                      style={{
+                        ...
+                        styles.secondaryBtn,
+                        padding: '4px 12px',
+                        border: 'none',
                         width: '76px',
                         minWidth: '76px',
                         textAlign: 'center',
                         background: viewMode === 'edit' ? dashboardPalette.white : 'transparent'
-                       }}>
+                      }}>
                       Edit
                     </button>
                     <button
                       type="button"
                       onClick={() => setViewMode('preview')}
-                      style={{ ...
-                        styles.secondaryBtn, 
+                      style={{
+                        ...
+                        styles.secondaryBtn,
                         padding: '4px 12px',
-                        border: 'none', 
+                        border: 'none',
                         width: '76px',
                         minWidth: '76px',
                         textAlign: 'center',
                         background: viewMode === 'preview' ? dashboardPalette.white : 'transparent'
-                        }}>
+                      }}>
                       Preview
                     </button>
                   </div>
@@ -726,47 +959,51 @@ export default function CreateQuestion() {
               </div>
 
               {viewMode === 'preview' ? (
-                <div style={{ ...
-                styles.input,
-                minHeight: '300px',
-                padding: '12px',
-                border: `1px solid ${dashboardPalette.border}`,
-                borderRadius: '8px',
-                overflow: 'auto' }}>
+                <div style={{
+                  ...
+                  styles.input,
+                  minHeight: '300px',
+                  padding: '12px',
+                  border: `1px solid ${dashboardPalette.border}`,
+                  borderRadius: '8px',
+                  overflow: 'auto'
+                }}>
                   <ReactMarkdown
                     remarkPlugins={[remarkGfm, remarkMath]}
                     rehypePlugins={[rehypeKatex]}
                     components={{
                       code({ node, inline, className, children, ...props }) {
                         return inline ? (
-                          <code style={{ 
+                          <code style={{
                             background: dashboardPalette.surface,
                             padding: '0.2rem 0.4rem',
                             borderRadius: '3px',
                             fontSize: '0.9em',
                             fontFamily: 'monospace'
-                          }} 
+                          }}
                             {...props}>{children}</code>
                         ) : (
-                          <pre style={{ 
-                            background: '#2d2d2d', 
-                            color: '#f8f8f2', 
-                            padding: '1rem', 
+                          <pre style={{
+                            background: '#2d2d2d',
+                            color: '#f8f8f2',
+                            padding: '1rem',
                             borderRadius: '4px',
-                             overflow: 'auto', 
-                             fontSize: '0.875rem' 
-                            }}>
+                            overflow: 'auto',
+                            fontSize: '0.875rem'
+                          }}>
                             <code className={className} {...props}>{children}</code>
                           </pre>
                         );
                       },
-                      p({ children }) { return <p 
-                        style={{ 
-                          margin: '0 0 0.5rem 0', 
-                          fontSize: '1rem', 
-                          lineHeight: '1.5'
-                         }}>
-                          {children}</p>; }
+                      p({ children }) {
+                        return <p
+                          style={{
+                            margin: '0 0 0.5rem 0',
+                            fontSize: '1rem',
+                            lineHeight: '1.5'
+                          }}>
+                          {children}</p>;
+                      }
                     }}
                   >
                     {formData.text || "*Nothing to preview yet...*"}
@@ -779,7 +1016,8 @@ export default function CreateQuestion() {
                   onChange={handleInputChange}
                   onKeyDown={handleTextareaKeyDown}
                   placeholder="Supports Markdown & LaTeX: $E=mc^2$"
-                      style={{ ...
+                  style={{
+                    ...
                     styles.input,
                     minHeight: '300px',
                     padding: '12px',
@@ -797,20 +1035,20 @@ export default function CreateQuestion() {
                   {isTrueFalse() ? 'Select the correct answer' : 'Answer Choices (Select the correct one)'}
                 </label>
                 {isTrueFalse() ? (
-                  <div style={{ 
-                    display: 'flex', 
-                    flexDirection: 'column', 
-                    gap: '12px' 
-                    }}>
+                  <div style={{
+                    display: 'flex',
+                    flexDirection: 'column',
+                    gap: '12px'
+                  }}>
                     {['True', 'False'].map((choice) => (
                       <div key={choice} style={styles.choiceRow}>
                         <input type="radio" name="correct-choice" style={styles.radio} checked={formData.correct_answer === choice} onChange={() => setCorrectAnswer(choice)} />
-                        <span style={{ 
-                          flex: 1, 
-                          padding: '12px', 
-                          fontSize: '16px', 
-                          color: '#1a202c' 
-                          }}>{choice}</span>
+                        <span style={{
+                          flex: 1,
+                          padding: '12px',
+                          fontSize: '16px',
+                          color: '#1a202c'
+                        }}>{choice}</span>
                       </div>
                     ))}
                   </div>
@@ -821,25 +1059,29 @@ export default function CreateQuestion() {
                         <input type="radio" name="correct-choice" style={styles.radio} checked={formData.correct_answer === choice && choice !== ''} onChange={() => setCorrectAnswer(choice)} />
                         <input type="text" value={choice} placeholder={`Option ${index + 1}`} style={styles.input} onChange={(e) => handleAnswerChange(index, e.target.value)} />
                         {formData.answer_choices.length > 2 && (
-                          <button type="button" style={{ 
-                            border: 'none', 
-                            background: 'none', 
-                            color: '#e53e3e', 
-                            cursor: 'pointer' 
+                          <button type="button" style={{
+                            border: 'none',
+                            background: 'none',
+                            color: '#e53e3e',
+                            cursor: 'pointer'
                           }} onClick={() => removeAnswerChoice(index)}>✕</button>
                         )}
                       </div>
                     ))}
-                    <button type="button" style={{ ...
+                    <button type="button" style={{
+                      ...
                       styles.secondaryBtn,
-                      width: '100%', 
-                      marginTop: '12px', 
-                      borderStyle: 'dashed' 
-                      }} onClick={addAnswerChoice}>+ Add Another Option</button>
+                      width: '100%',
+                      marginTop: '12px',
+                      borderStyle: 'dashed'
+                    }} onClick={addAnswerChoice}>+ Add Another Option</button>
                   </>
                 )}
               </div>
             )}
+
+            {/* Short Answer builder */}
+            {isShortAnswer() && renderShortAnswerCard()}
 
             {/* Rubric Builder */}
             {needsRubric() && (
@@ -848,82 +1090,82 @@ export default function CreateQuestion() {
                   <div style={{
                     padding: '12px 16px',
                     background: dashboardPalette.surface,
-                     border: `1px solid ${dashboardPalette.border}`,
-                     borderRadius: '8px',
-                     marginBottom: '20px'
-                     }}>
-                    <div style={{ 
+                    border: `1px solid ${dashboardPalette.border}`,
+                    borderRadius: '8px',
+                    marginBottom: '20px'
+                  }}>
+                    <div style={{
                       fontSize: '14px',
                       fontWeight: '600',
                       color: dashboardPalette.navy,
                       marginBottom: '6px'
-                      }}>
-                        📋 Parts vs Rubric</div>
-                    <ul style={{ 
+                    }}>
+                      📋 Parts vs Rubric</div>
+                    <ul style={{
                       margin: 0,
                       paddingLeft: '20px',
                       fontSize: '13px',
                       color: dashboardPalette.text,
                       lineHeight: 1.6
-                      }}>
+                    }}>
                       <li><strong>Parts</strong> = Sub-questions.</li>
                       <li><strong>Rubric</strong> = Grading criteria per part.</li>
                     </ul>
                   </div>
                 )}
 
-                <div style={{ 
-                  display: 'flex', 
-                  justifyContent: 'space-between', 
-                  alignItems: 'center', 
-                  marginBottom: '16px' 
-                  }}>
+                <div style={{
+                  display: 'flex',
+                  justifyContent: 'space-between',
+                  alignItems: 'center',
+                  marginBottom: '16px'
+                }}>
                   <label style={styles.label}>{isFreeResponse() ? 'Question Parts' : 'Grading Rubric'}</label>
-                  <span style={{ 
+                  <span style={{
                     fontSize: '14px',
                     color: dashboardPalette.muted
-                    }}>Total: {formData.rubric_parts.reduce((sum, p) => sum + getPartTotalPoints(p), 0)} points</span>
+                  }}>Total: {formData.rubric_parts.reduce((sum, p) => sum + getPartTotalPoints(p), 0)} points</span>
                 </div>
 
                 {formData.rubric_parts.map((part, partIndex) => (
-                  <div key={partIndex} style={{ 
+                  <div key={partIndex} style={{
                     background: dashboardPalette.surface,
                     border: `1px solid ${dashboardPalette.border}`,
                     borderRadius: '8px',
                     padding: '16px',
                     marginBottom: '16px'
+                  }}>
+                    <div style={{
+                      display: 'flex',
+                      justifyContent: 'space-between',
+                      alignItems: 'center',
+                      marginBottom: '12px'
                     }}>
-                    <div style={{ 
-                      display: 'flex', 
-                      justifyContent: 'space-between', 
-                      alignItems: 'center', 
-                      marginBottom: '12px' 
-                      }}>
                       {isFreeResponse() ? (
                         <input type="text" value={part.part_label} onChange={(e) => updatePartLabel(partIndex, e.target.value)} style={{ ...styles.input, width: '140px', fontWeight: '600', background: dashboardPalette.white }} placeholder="Part A" />
                       ) : (
                         <span style={{ fontWeight: '600', color: dashboardPalette.text }}>Grading levels</span>
                       )}
                       {isFreeResponse() && formData.rubric_parts.length > 1 && (
-                        <button type="button" style={{ 
+                        <button type="button" style={{
                           border: `1px solid ${dashboardPalette.dangerBorder}`,
                           background: dashboardPalette.white,
                           color: dashboardPalette.dangerText,
                           cursor: 'pointer',
                           padding: '6px 12px',
                           borderRadius: '6px',
-                          fontSize: '13px' 
+                          fontSize: '13px'
                         }} onClick={() => removePart(partIndex)}>Remove Part</button>
                       )}
                     </div>
 
-                    <div style={{ 
+                    <div style={{
                       marginTop: '12px',
                       paddingTop: '12px',
                       borderTop: `1px solid ${dashboardPalette.border}`
-                      }}>
+                    }}>
                       {part.rubric_levels.map((level, levelIndex) => (
-                        <div key={levelIndex} style={{ 
+                        <div key={levelIndex} style={{
                           display: 'flex',
                           alignItems: 'flex-start',
                           gap: '12px',
@@ -932,20 +1174,20 @@ export default function CreateQuestion() {
                           padding: '10px 12px',
                           borderRadius: '6px',
                           border: `1px solid ${dashboardPalette.border}`
+                        }}>
+                          <div style={{
+                            display: 'flex',
+                            alignItems: 'center',
+                            gap: '6px',
+                            flexShrink: 0
                           }}>
-                          <div style={{ 
-                            display: 'flex', 
-                            alignItems: 'center', 
-                            gap: '6px', 
-                            flexShrink: 0 
-                            }}>
                             <span style={{ fontWeight: '600' }}>+</span>
                             <input type="number" value={level.points} onChange={(e) => updateRubricLevel(partIndex, levelIndex, 'points', e.target.value)} style={{ ...styles.input, width: '56px', textAlign: 'center' }} min="0" />
                             <span style={{ fontSize: '13px' }}>pts</span>
                           </div>
                           <input type="text" value={level.criteria} onChange={(e) => updateRubricLevel(partIndex, levelIndex, 'criteria', e.target.value)} placeholder="Criteria..." style={{ ...styles.input, flex: 1 }} />
                           {part.rubric_levels.length > 1 && (
-                            <button type="button" style={{ 
+                            <button type="button" style={{
                               border: 'none',
                               background: 'none',
                               color: dashboardPalette.muted,
@@ -954,25 +1196,27 @@ export default function CreateQuestion() {
                           )}
                         </div>
                       ))}
-                      <button type="button" style={{ ...
-                        styles.secondaryBtn, 
+                      <button type="button" style={{
+                        ...
+                        styles.secondaryBtn,
                         padding: '8px 14px',
-                        fontSize: '13px', 
-                        borderStyle: 'dashed' 
-                        }} onClick={() => addRubricLevel(partIndex)}>+ Add level</button>
+                        fontSize: '13px',
+                        borderStyle: 'dashed'
+                      }} onClick={() => addRubricLevel(partIndex)}>+ Add level</button>
                     </div>
                   </div>
                 ))}
 
                 {isFreeResponse() && (
-                  <button type="button" style={{ ...
-                  styles.secondaryBtn,
-                  width: '100%', 
-                  borderStyle: 'dashed', 
-                  display: 'flex', 
-                  alignItems: 'center', 
-                  justifyContent: 'center', 
-                  gap: '8px'
+                  <button type="button" style={{
+                    ...
+                    styles.secondaryBtn,
+                    width: '100%',
+                    borderStyle: 'dashed',
+                    display: 'flex',
+                    alignItems: 'center',
+                    justifyContent: 'center',
+                    gap: '8px'
                   }} onClick={addPart}>
                     <span style={{ fontSize: '18px' }}>+</span> Add Another Part
                   </button>
@@ -1000,32 +1244,33 @@ export default function CreateQuestion() {
           </div>
 
           {/* Sidebar / Split View (Right Column) */}
-          <aside style={{ 
+          <aside style={{
             position: 'sticky',
-            top: '24px' }}>
+            top: '24px'
+          }}>
             {isSplitView ? (
               /* --- SPLIT VIEW PREVIEW --- */
               <div style={styles.card}>
-                <div style={{ 
-                  display: 'flex', 
+                <div style={{
+                  display: 'flex',
                   justifyContent: 'space-between',
-                  alignItems: 'center', 
-                  marginBottom: '16px' 
-                  }}>
-                  <h3 style={{ 
+                  alignItems: 'center',
+                  marginBottom: '16px'
+                }}>
+                  <h3 style={{
                     margin: 0,
                     fontSize: '14px',
                     color: dashboardPalette.muted,
-                    textTransform: 'uppercase' 
-                    }}>Student View</h3>
-                    <span style={{ fontSize: '11px', color: dashboardPalette.muted, fontStyle: 'italic' }}>Live Preview</span>
+                    textTransform: 'uppercase'
+                  }}>Student View</h3>
+                  <span style={{ fontSize: '11px', color: dashboardPalette.muted, fontStyle: 'italic' }}>Live Preview</span>
                 </div>
-                <div style={{ 
+                <div style={{
                   border: `1px solid ${dashboardPalette.border}`,
                   borderRadius: '8px',
                   background: dashboardPalette.surface,
-                  overflow: 'hidden' 
-                  }}>
+                  overflow: 'hidden'
+                }}>
                   <StudentPreview
                     inline={true}
                     isPreviewMode={false}

--- a/frontend/src/pages/EditQuestion.jsx
+++ b/frontend/src/pages/EditQuestion.jsx
@@ -20,6 +20,11 @@ const DEFAULT_RUBRIC_PARTS = [
     ]
   }
 ];
+const DEFAULT_SHORT_ANSWER_CONFIG = {
+  valid_answers: [],
+  input_restriction: 'any',
+  points: 1,
+};
 
 export default function EditQuestion() {
   const getQuestionId = () => {
@@ -50,7 +55,7 @@ export default function EditQuestion() {
     answer_choices: ['', '', '', ''],
     correct_answer: '',
     rubric_parts: DEFAULT_RUBRIC_PARTS,
-    short_answer_expected: '',
+    short_answer_config: { ...DEFAULT_SHORT_ANSWER_CONFIG },
     coding_config: createDefaultCodingConfig(),
   });
   const [originalImageUrl, setOriginalImageUrl] = useState(null);
@@ -121,6 +126,17 @@ export default function EditQuestion() {
         }
 
         if (active) {
+          // Detect short answer config (new format)
+          let shortAnswerConfig = { ...DEFAULT_SHORT_ANSWER_CONFIG };
+          if (question.question_type === 'short_answer') {
+            try {
+              const parsed = JSON.parse(question.answer_choices || '{}');
+              if (parsed && !Array.isArray(parsed) && parsed.valid_answers) {
+                shortAnswerConfig = parsed;
+              }
+            } catch (e) { /* use default */ }
+          }
+
           setFormData({
             title: question.title || '',
             text: question.text || '',
@@ -134,7 +150,7 @@ export default function EditQuestion() {
             answer_choices: answerChoices,
             correct_answer: question.question_type === 'short_answer' ? '' : (question.correct_answer || ''),
             rubric_parts: rubricParts,
-            short_answer_expected: '',
+            short_answer_config: shortAnswerConfig,
             coding_config: codingConfig,
           });
         }
@@ -264,8 +280,7 @@ export default function EditQuestion() {
       }
       // When switching to Short Answer, collapse to single part (no multiple parts for short answer)
       if (name === 'question_type' && value === 'short_answer') {
-        const firstPart = next.rubric_parts?.[0] || { part_label: 'Part A', rubric_levels: [{ points: 6, criteria: '' }, { points: 3, criteria: '' }, { points: 0, criteria: '' }] };
-        next.rubric_parts = [firstPart];
+        next.short_answer_config = { ...DEFAULT_SHORT_ANSWER_CONFIG };
       }
       if (name === 'question_type' && value === 'coding') {
         next.coding_config = normalizeEditableCodingConfig(next.coding_config);
@@ -379,6 +394,39 @@ export default function EditQuestion() {
     return levels.length > 0 ? Math.max(...levels.map(l => parseInt(l.points) || 0)) : 0;
   };
 
+  //helper funcs
+  // Short answer config helpers
+  const updateShortAnswerConfig = (patch) => {
+    setFormData(prev => ({
+      ...prev,
+      short_answer_config: { ...prev.short_answer_config, ...patch }
+    }));
+  };
+
+  const addValidAnswer = () => {
+    setFormData(prev => ({
+      ...prev,
+      short_answer_config: {
+        ...prev.short_answer_config,
+        valid_answers: [
+          ...prev.short_answer_config.valid_answers,
+          { value: '', case_sensitive: false }
+        ]
+      }
+    }));
+  };
+
+  const updateValidAnswer = (index, patch) => {
+    const updated = [...formData.short_answer_config.valid_answers];
+    updated[index] = { ...updated[index], ...patch };
+    updateShortAnswerConfig({ valid_answers: updated });
+  };
+
+  const removeValidAnswer = (index) => {
+    const updated = formData.short_answer_config.valid_answers.filter((_, i) => i !== index);
+    updateShortAnswerConfig({ valid_answers: updated });
+  };
+
   // Check if question type needs answer choices
   const needsAnswerChoices = () => {
     return ['mcq', 'true_false'].includes(formData.question_type);
@@ -389,7 +437,7 @@ export default function EditQuestion() {
     return formData.question_type === 'true_false';
   };
 
-  // Check if question type is free response
+  // Check if  type is free response
   const isFreeResponse = () => {
     return formData.question_type === 'fr';
   };
@@ -404,9 +452,7 @@ export default function EditQuestion() {
   };
 
   // Check if question type needs rubric (both FR and Short Answer)
-  const needsRubric = () => {
-    return formData.question_type === 'fr' || formData.question_type === 'short_answer';
-  };
+  const needsRubric = () => formData.question_type === 'fr';
 
   const handleImageChange = (e) => {
     const file = e.target.files[0];
@@ -501,6 +547,14 @@ export default function EditQuestion() {
         return;
       }
     }
+    if (isShortAnswer()) {
+      const filledAnswers = formData.short_answer_config.valid_answers.filter(a => a.value.trim());
+      if (filledAnswers.length === 0) {
+        setError('Add at least one valid answer for the short answer question');
+        setLoading(false);
+        return;
+      }
+    }
 
     if (isCoding()) {
       const codingError = getCodingAuthoringError(formData.coding_config);
@@ -547,12 +601,17 @@ export default function EditQuestion() {
         const validAnswers = isTrueFalse() ? ['True', 'False'] : formData.answer_choices.filter(a => a.trim());
         answerChoicesData = JSON.stringify(validAnswers);
         correctAnswerData = formData.correct_answer;
+      } else if (isShortAnswer()) {
+        const cleanConfig = {
+          ...formData.short_answer_config,
+          valid_answers: formData.short_answer_config.valid_answers.filter(a => a.value.trim()),
+        };
+        answerChoicesData = JSON.stringify(cleanConfig);
+        correctAnswerData = 'short_answer';
       } else if (needsRubric()) {
-        // Store rubric parts for both free response and short answer
         answerChoicesData = JSON.stringify(formData.rubric_parts);
         correctAnswerData = 'rubric';
       }
-
       await updateQuestion(questionId, {
         title: formData.title,
         text: formData.text,
@@ -578,6 +637,179 @@ export default function EditQuestion() {
     } finally {
       setLoading(false);
     }
+  };
+
+  const renderShortAnswerCard = () => {
+    const { valid_answers, input_restriction, points } = formData.short_answer_config;
+    const inputTypeForAnswerField = input_restriction === 'numbers' ? 'number' : 'text';
+
+    return (
+      <div style={styles.card}>
+        <label style={styles.label}>Short Answer Setup</label>
+
+        {/* Input restriction toggle */}
+        <div style={{ marginBottom: '20px' }}>
+          <label style={{ ...styles.label, fontSize: '12px', textTransform: 'uppercase', letterSpacing: '0.04em', marginBottom: '10px' }}>
+            Restrict student input type
+          </label>
+          <div style={{ display: 'flex', gap: '8px', flexWrap: 'wrap' }}>
+            {[
+              { value: 'any', label: 'Any text' },
+              { value: 'numbers', label: 'Numbers only' },
+              { value: 'letters', label: 'Letters only' },
+            ].map((opt) => {
+              const isActive = input_restriction === opt.value;
+              return (
+                <button
+                  key={opt.value}
+                  type="button"
+                  onClick={() => updateShortAnswerConfig({ input_restriction: opt.value })}
+                  style={{
+                    padding: '6px 16px',
+                    borderRadius: '99px',
+                    fontSize: '13px',
+                    fontWeight: 600,
+                    cursor: 'pointer',
+                    border: isActive ? '2px solid #1a3a5c' : '1px solid #cbd5e0',
+                    background: isActive ? '#e8f0fe' : 'white',
+                    color: isActive ? '#1a3a5c' : '#4a5568',
+                  }}
+                >
+                  {opt.label}
+                </button>
+              );
+            })}
+          </div>
+        </div>
+
+        {/* Valid answers list */}
+        <div style={{ marginBottom: '20px' }}>
+          <div style={{ display: 'flex', alignItems: 'baseline', gap: '8px', marginBottom: '10px' }}>
+            <label style={{ ...styles.label, margin: 0 }}>Valid answers</label>
+            <span style={{ fontSize: '12px', color: '#6b7280' }}>
+              Students must match one of these to receive credit
+            </span>
+          </div>
+
+          {valid_answers.length === 0 && (
+            <div style={{
+              padding: '16px',
+              background: '#f8fafc',
+              border: '1px dashed #cbd5e0',
+              borderRadius: '8px',
+              textAlign: 'center',
+              fontSize: '13px',
+              color: '#6b7280',
+              marginBottom: '10px'
+            }}>
+              No valid answers added yet. Add at least one.
+            </div>
+          )}
+
+          {valid_answers.map((ans, idx) => (
+            <div
+              key={idx}
+              style={{
+                display: 'flex',
+                alignItems: 'center',
+                gap: '10px',
+                marginBottom: '8px',
+                padding: '10px 12px',
+                background: '#f8fafc',
+                border: '1px solid #e2e8f0',
+                borderRadius: '8px',
+              }}
+            >
+              <input
+                type={inputTypeForAnswerField}
+                value={ans.value}
+                placeholder={
+                  input_restriction === 'numbers' ? 'e.g. 42'
+                    : input_restriction === 'letters' ? 'e.g. oxygen'
+                      : 'e.g. O(log n)'
+                }
+                onChange={(e) => updateValidAnswer(idx, { value: e.target.value })}
+                style={{ ...styles.input, flex: 1 }}
+              />
+
+              {input_restriction !== 'numbers' && (
+                <label style={{
+                  display: 'flex',
+                  alignItems: 'center',
+                  gap: '5px',
+                  fontSize: '13px',
+                  color: '#6b7280',
+                  whiteSpace: 'nowrap',
+                  cursor: 'pointer',
+                  flexShrink: 0,
+                }}>
+                  <input
+                    type="checkbox"
+                    checked={!ans.case_sensitive}
+                    onChange={(e) => updateValidAnswer(idx, { case_sensitive: !e.target.checked })}
+                    style={{ width: '15px', height: '15px', cursor: 'pointer' }}
+                  />
+                  Case-insensitive
+                </label>
+              )}
+
+              <button
+                type="button"
+                onClick={() => removeValidAnswer(idx)}
+                style={{
+                  border: 'none',
+                  background: 'none',
+                  color: '#94a3b8',
+                  cursor: 'pointer',
+                  fontSize: '20px',
+                  lineHeight: 1,
+                  padding: '0 2px',
+                  flexShrink: 0,
+                }}
+                aria-label="Remove answer"
+              >
+                ×
+              </button>
+            </div>
+          ))}
+
+          <button
+            type="button"
+            onClick={addValidAnswer}
+            style={{
+              ...styles.secondaryBtn,
+              borderStyle: 'dashed',
+              padding: '8px 16px',
+              fontSize: '13px',
+              height: 'auto',
+              marginTop: '4px',
+            }}
+          >
+            + Add valid answer
+          </button>
+        </div>
+
+        {/* Points */}
+        <div style={{
+          display: 'flex',
+          alignItems: 'center',
+          gap: '12px',
+          paddingTop: '16px',
+          borderTop: '1px solid #e2e8f0',
+        }}>
+          <label style={{ ...styles.label, margin: 0, whiteSpace: 'nowrap' }}>
+            Points for correct match:
+          </label>
+          <input
+            type="number"
+            min="0"
+            value={points}
+            onChange={(e) => updateShortAnswerConfig({ points: parseInt(e.target.value) || 0 })}
+            style={{ ...styles.input, width: '80px' }}
+          />
+        </div>
+      </div>
+    );
   };
 
   const renderMetadataCard = () => (
@@ -732,36 +964,39 @@ export default function EditQuestion() {
                     <button
                       type="button"
                       onClick={() => setViewMode('edit')}
-                      style={{ ...
-                        styles.secondaryBtn, 
-                        padding: '4px 12px', 
-                        border: 'none', 
-                        background: viewMode === 'edit' ? 'white' : 'transparent', 
+                      style={{
+                        ...
+                        styles.secondaryBtn,
+                        padding: '4px 12px',
+                        border: 'none',
+                        background: viewMode === 'edit' ? 'white' : 'transparent',
                         boxShadow: viewMode === 'edit' ? '0 1px 2px rgba(0,0,0,0.1)' : 'none'
-                       }}>
+                      }}>
                       Edit
                     </button>
                     <button
                       type="button"
                       onClick={() => setViewMode('preview')}
-                      style={{ ...
-                        styles.secondaryBtn, 
+                      style={{
+                        ...
+                        styles.secondaryBtn,
                         padding: '4px 12px',
-                        border: 'none', 
-                        background: viewMode === 'preview' ? 'white' : 'transparent', 
-                        boxShadow: viewMode === 'preview' ? '0 1px 2px rgba(0,0,0,0.1)' : 'none' 
-                        }}>
+                        border: 'none',
+                        background: viewMode === 'preview' ? 'white' : 'transparent',
+                        boxShadow: viewMode === 'preview' ? '0 1px 2px rgba(0,0,0,0.1)' : 'none'
+                      }}>
                       Preview
                     </button>
                     <button
                       type="button"
                       onClick={() => setViewMode('split')}
-                      style={{ ...
-                      styles.secondaryBtn, 
-                      padding: '4px 12px', 
-                      border: 'none', 
-                      background: viewMode === 'split' ? 'white' : 'transparent', 
-                      boxShadow: viewMode === 'split' ? '0 1px 2px rgba(0,0,0,0.1)' : 'none' 
+                      style={{
+                        ...
+                        styles.secondaryBtn,
+                        padding: '4px 12px',
+                        border: 'none',
+                        background: viewMode === 'split' ? 'white' : 'transparent',
+                        boxShadow: viewMode === 'split' ? '0 1px 2px rgba(0,0,0,0.1)' : 'none'
                       }}>
                       Student View
                     </button>
@@ -770,47 +1005,51 @@ export default function EditQuestion() {
               </div>
 
               {viewMode === 'preview' ? (
-                <div style={{ ...
-                styles.input, 
-                minHeight: '300px', 
-                padding: '12px', 
-                border: '1px solid #edf2f7', 
-                borderRadius: '8px', 
-                overflow: 'auto' }}>
+                <div style={{
+                  ...
+                  styles.input,
+                  minHeight: '300px',
+                  padding: '12px',
+                  border: '1px solid #edf2f7',
+                  borderRadius: '8px',
+                  overflow: 'auto'
+                }}>
                   <ReactMarkdown
                     remarkPlugins={[remarkGfm, remarkMath]}
                     rehypePlugins={[rehypeKatex]}
                     components={{
                       code({ node, inline, className, children, ...props }) {
                         return inline ? (
-                          <code style={{ 
-                            background: '#e9ecef', 
-                            padding: '0.2rem 0.4rem', 
-                            borderRadius: '3px', 
-                            fontSize: '0.9em', 
-                            fontFamily: 'monospace' 
-                          }} 
+                          <code style={{
+                            background: '#e9ecef',
+                            padding: '0.2rem 0.4rem',
+                            borderRadius: '3px',
+                            fontSize: '0.9em',
+                            fontFamily: 'monospace'
+                          }}
                             {...props}>{children}</code>
                         ) : (
-                          <pre style={{ 
-                            background: '#2d2d2d', 
-                            color: '#f8f8f2', 
-                            padding: '1rem', 
+                          <pre style={{
+                            background: '#2d2d2d',
+                            color: '#f8f8f2',
+                            padding: '1rem',
                             borderRadius: '4px',
-                             overflow: 'auto', 
-                             fontSize: '0.875rem' 
-                            }}>
+                            overflow: 'auto',
+                            fontSize: '0.875rem'
+                          }}>
                             <code className={className} {...props}>{children}</code>
                           </pre>
                         );
                       },
-                      p({ children }) { return <p 
-                        style={{ 
-                          margin: '0 0 0.5rem 0', 
-                          fontSize: '1rem', 
-                          lineHeight: '1.5'
-                         }}>
-                          {children}</p>; }
+                      p({ children }) {
+                        return <p
+                          style={{
+                            margin: '0 0 0.5rem 0',
+                            fontSize: '1rem',
+                            lineHeight: '1.5'
+                          }}>
+                          {children}</p>;
+                      }
                     }}
                   >
                     {formData.text || "*Nothing to preview yet...*"}
@@ -823,12 +1062,13 @@ export default function EditQuestion() {
                   onChange={handleInputChange}
                   onKeyDown={handleTextareaKeyDown}
                   placeholder="Supports Markdown & LaTeX: $E=mc^2$"
-                  style={{ ...
-                    styles.input, 
-                    minHeight: '300px', 
-                    padding: '12px', 
-                    fontFamily: 'monospace', 
-                    lineHeight: '1.5' 
+                  style={{
+                    ...
+                    styles.input,
+                    minHeight: '300px',
+                    padding: '12px',
+                    fontFamily: 'monospace',
+                    lineHeight: '1.5'
                   }}
                 />
               )}
@@ -841,20 +1081,20 @@ export default function EditQuestion() {
                   {isTrueFalse() ? 'Select the correct answer' : 'Answer Choices (Select the correct one)'}
                 </label>
                 {isTrueFalse() ? (
-                  <div style={{ 
-                    display: 'flex', 
-                    flexDirection: 'column', 
-                    gap: '12px' 
-                    }}>
+                  <div style={{
+                    display: 'flex',
+                    flexDirection: 'column',
+                    gap: '12px'
+                  }}>
                     {['True', 'False'].map((choice) => (
                       <div key={choice} style={styles.choiceRow}>
                         <input type="radio" name="correct-choice" style={styles.radio} checked={formData.correct_answer === choice} onChange={() => setCorrectAnswer(choice)} />
-                        <span style={{ 
-                          flex: 1, 
-                          padding: '12px', 
-                          fontSize: '16px', 
-                          color: '#1a202c' 
-                          }}>{choice}</span>
+                        <span style={{
+                          flex: 1,
+                          padding: '12px',
+                          fontSize: '16px',
+                          color: '#1a202c'
+                        }}>{choice}</span>
                       </div>
                     ))}
                   </div>
@@ -865,158 +1105,164 @@ export default function EditQuestion() {
                         <input type="radio" name="correct-choice" style={styles.radio} checked={formData.correct_answer === choice && choice !== ''} onChange={() => setCorrectAnswer(choice)} />
                         <input type="text" value={choice} placeholder={`Option ${index + 1}`} style={styles.input} onChange={(e) => handleAnswerChange(index, e.target.value)} />
                         {formData.answer_choices.length > 2 && (
-                          <button type="button" style={{ 
-                            border: 'none', 
-                            background: 'none', 
-                            color: '#e53e3e', 
-                            cursor: 'pointer' 
+                          <button type="button" style={{
+                            border: 'none',
+                            background: 'none',
+                            color: '#e53e3e',
+                            cursor: 'pointer'
                           }} onClick={() => removeAnswerChoice(index)}>✕</button>
                         )}
                       </div>
                     ))}
-                    <button type="button" style={{ ...
+                    <button type="button" style={{
+                      ...
                       styles.secondaryBtn,
-                      width: '100%', 
-                      marginTop: '12px', 
-                      borderStyle: 'dashed' 
-                      }} onClick={addAnswerChoice}>+ Add Another Option</button>
+                      width: '100%',
+                      marginTop: '12px',
+                      borderStyle: 'dashed'
+                    }} onClick={addAnswerChoice}>+ Add Another Option</button>
                   </>
                 )}
               </div>
             )}
+
+            {/* Short Answer builder */}
+            {isShortAnswer() && renderShortAnswerCard()}
 
             {/* Rubric Builder */}
             {needsRubric() && (
               <div style={styles.card}>
                 {isFreeResponse() && (
                   <div style={{
-                    padding: '12px 16px', 
+                    padding: '12px 16px',
                     background: '#eff6ff',
-                     border: '1px solid #bfdbfe', 
-                     borderRadius: '8px', 
-                     marginBottom: '20px' 
-                     }}>
-                    <div style={{ 
-                      fontSize: '14px', 
-                      fontWeight: '600', 
-                      color: '#1e40af', 
-                      marginBottom: '6px' 
-                      }}>
-                        📋 Parts vs Rubric</div>
-                    <ul style={{ 
-                      margin: 0, 
-                      paddingLeft: '20px', 
-                      fontSize: '13px', 
-                      color: '#1e3a8a', 
-                      lineHeight: 1.6 
-                      }}>
+                    border: '1px solid #bfdbfe',
+                    borderRadius: '8px',
+                    marginBottom: '20px'
+                  }}>
+                    <div style={{
+                      fontSize: '14px',
+                      fontWeight: '600',
+                      color: '#1e40af',
+                      marginBottom: '6px'
+                    }}>
+                      📋 Parts vs Rubric</div>
+                    <ul style={{
+                      margin: 0,
+                      paddingLeft: '20px',
+                      fontSize: '13px',
+                      color: '#1e3a8a',
+                      lineHeight: 1.6
+                    }}>
                       <li><strong>Parts</strong> = Sub-questions.</li>
                       <li><strong>Rubric</strong> = Grading criteria per part.</li>
                     </ul>
                   </div>
                 )}
 
-                <div style={{ 
-                  display: 'flex', 
-                  justifyContent: 'space-between', 
-                  alignItems: 'center', 
-                  marginBottom: '16px' 
-                  }}>
+                <div style={{
+                  display: 'flex',
+                  justifyContent: 'space-between',
+                  alignItems: 'center',
+                  marginBottom: '16px'
+                }}>
                   <label style={styles.label}>{isFreeResponse() ? 'Question Parts' : 'Grading Rubric'}</label>
-                  <span style={{ 
-                    fontSize: '14px', 
-                    color: '#6b7280' 
-                    }}>Total: {formData.rubric_parts.reduce((sum, p) => sum + getPartTotalPoints(p), 0)} points</span>
+                  <span style={{
+                    fontSize: '14px',
+                    color: '#6b7280'
+                  }}>Total: {formData.rubric_parts.reduce((sum, p) => sum + getPartTotalPoints(p), 0)} points</span>
                 </div>
 
                 {formData.rubric_parts.map((part, partIndex) => (
-                  <div key={partIndex} style={{ 
-                    background: '#f8fafc', 
-                    border: '1px solid #e2e8f0', 
-                    borderRadius: '8px', 
-                    padding: '16px', 
-                    marginBottom: '16px' 
+                  <div key={partIndex} style={{
+                    background: '#f8fafc',
+                    border: '1px solid #e2e8f0',
+                    borderRadius: '8px',
+                    padding: '16px',
+                    marginBottom: '16px'
+                  }}>
+                    <div style={{
+                      display: 'flex',
+                      justifyContent: 'space-between',
+                      alignItems: 'center',
+                      marginBottom: '12px'
                     }}>
-                    <div style={{ 
-                      display: 'flex', 
-                      justifyContent: 'space-between', 
-                      alignItems: 'center', 
-                      marginBottom: '12px' 
-                      }}>
                       {isFreeResponse() ? (
                         <input type="text" value={part.part_label} onChange={(e) => updatePartLabel(partIndex, e.target.value)} style={{ ...styles.input, width: '140px', fontWeight: '600', background: 'white' }} placeholder="Part A" />
                       ) : (
                         <span style={{ fontWeight: '600', color: '#374151' }}>Grading levels</span>
                       )}
                       {isFreeResponse() && formData.rubric_parts.length > 1 && (
-                        <button type="button" style={{ 
-                          border: 'none', 
-                          background: '#fee2e2', 
-                          color: '#dc2626', 
-                          cursor: 'pointer', 
-                          padding: '6px 12px', 
-                          borderRadius: '6px', 
-                          fontSize: '13px' 
+                        <button type="button" style={{
+                          border: 'none',
+                          background: '#fee2e2',
+                          color: '#dc2626',
+                          cursor: 'pointer',
+                          padding: '6px 12px',
+                          borderRadius: '6px',
+                          fontSize: '13px'
                         }} onClick={() => removePart(partIndex)}>Remove Part</button>
                       )}
                     </div>
 
-                    <div style={{ 
-                      marginTop: '12px', 
-                      paddingTop: '12px', 
-                      borderTop: '1px solid #e2e8f0' 
-                      }}>
+                    <div style={{
+                      marginTop: '12px',
+                      paddingTop: '12px',
+                      borderTop: '1px solid #e2e8f0'
+                    }}>
                       {part.rubric_levels.map((level, levelIndex) => (
-                        <div key={levelIndex} style={{ 
-                          display: 'flex', 
-                          alignItems: 'flex-start', 
-                          gap: '12px', 
-                          marginBottom: '10px', 
-                          background: 'white', 
-                          padding: '10px 12px', 
-                          borderRadius: '6px', 
-                          border: '1px solid #e2e8f0' 
+                        <div key={levelIndex} style={{
+                          display: 'flex',
+                          alignItems: 'flex-start',
+                          gap: '12px',
+                          marginBottom: '10px',
+                          background: 'white',
+                          padding: '10px 12px',
+                          borderRadius: '6px',
+                          border: '1px solid #e2e8f0'
+                        }}>
+                          <div style={{
+                            display: 'flex',
+                            alignItems: 'center',
+                            gap: '6px',
+                            flexShrink: 0
                           }}>
-                          <div style={{ 
-                            display: 'flex', 
-                            alignItems: 'center', 
-                            gap: '6px', 
-                            flexShrink: 0 
-                            }}>
                             <span style={{ fontWeight: '600' }}>+</span>
                             <input type="number" value={level.points} onChange={(e) => updateRubricLevel(partIndex, levelIndex, 'points', e.target.value)} style={{ ...styles.input, width: '56px', textAlign: 'center' }} min="0" />
                             <span style={{ fontSize: '13px' }}>pts</span>
                           </div>
                           <input type="text" value={level.criteria} onChange={(e) => updateRubricLevel(partIndex, levelIndex, 'criteria', e.target.value)} placeholder="Criteria..." style={{ ...styles.input, flex: 1 }} />
                           {part.rubric_levels.length > 1 && (
-                            <button type="button" style={{ 
-                              border: 'none', 
-                              background: 'none', 
-                              color: '#94a3b8', 
+                            <button type="button" style={{
+                              border: 'none',
+                              background: 'none',
+                              color: '#94a3b8',
                               cursor: 'pointer'
                             }} onClick={() => removeRubricLevel(partIndex, levelIndex)}>✕</button>
                           )}
                         </div>
                       ))}
-                      <button type="button" style={{ ...
-                        styles.secondaryBtn, 
+                      <button type="button" style={{
+                        ...
+                        styles.secondaryBtn,
                         padding: '8px 14px',
-                        fontSize: '13px', 
-                        borderStyle: 'dashed' 
-                        }} onClick={() => addRubricLevel(partIndex)}>+ Add level</button>
+                        fontSize: '13px',
+                        borderStyle: 'dashed'
+                      }} onClick={() => addRubricLevel(partIndex)}>+ Add level</button>
                     </div>
                   </div>
                 ))}
 
                 {isFreeResponse() && (
-                  <button type="button" style={{ ...
-                  styles.secondaryBtn,
-                  width: '100%', 
-                  borderStyle: 'dashed', 
-                  display: 'flex', 
-                  alignItems: 'center', 
-                  justifyContent: 'center', 
-                  gap: '8px'
+                  <button type="button" style={{
+                    ...
+                    styles.secondaryBtn,
+                    width: '100%',
+                    borderStyle: 'dashed',
+                    display: 'flex',
+                    alignItems: 'center',
+                    justifyContent: 'center',
+                    gap: '8px'
                   }} onClick={addPart}>
                     <span style={{ fontSize: '18px' }}>+</span> Add Another Part
                   </button>
@@ -1044,31 +1290,32 @@ export default function EditQuestion() {
           </div>
 
           {/* Sidebar / Split View (Right Column) */}
-          <aside style={{ 
+          <aside style={{
             position: 'sticky',
-            top: '20px' }}>
+            top: '20px'
+          }}>
             {viewMode === 'split' ? (
               /* --- SPLIT VIEW PREVIEW --- */
               <div style={styles.card}>
-                <div style={{ 
-                  display: 'flex', 
+                <div style={{
+                  display: 'flex',
                   justifyContent: 'space-between',
-                  alignItems: 'center', 
-                  marginBottom: '16px' 
-                  }}>
-                  <h3 style={{ 
-                    margin: 0, 
-                    fontSize: '14px', 
-                    color: '#64748b', 
-                    textTransform: 'uppercase' 
-                    }}>Student View</h3>
+                  alignItems: 'center',
+                  marginBottom: '16px'
+                }}>
+                  <h3 style={{
+                    margin: 0,
+                    fontSize: '14px',
+                    color: '#64748b',
+                    textTransform: 'uppercase'
+                  }}>Student View</h3>
                 </div>
-                <div style={{ 
-                  border: '1px solid #edf2f7', 
-                  borderRadius: '8px', 
-                  background: '#f8fafc', 
-                  overflow: 'hidden' 
-                  }}>
+                <div style={{
+                  border: '1px solid #edf2f7',
+                  borderRadius: '8px',
+                  background: '#f8fafc',
+                  overflow: 'hidden'
+                }}>
                   <StudentPreview
                     inline={true}
                     isPreviewMode={false}
@@ -1085,7 +1332,9 @@ export default function EditQuestion() {
                         ? JSON.stringify(sanitizeCodingConfigForSave(formData.coding_config))
                         : (formData.question_type === 'mcq' || formData.question_type === 'true_false')
                           ? JSON.stringify(formData.answer_choices)
-                          : JSON.stringify(formData.rubric_parts),
+                          : isShortAnswer()
+                            ? JSON.stringify(formData.short_answer_config)
+                            : JSON.stringify(formData.rubric_parts),
                       correct_answer: formData.correct_answer,
                       coding: isCoding() ? sanitizeCodingConfigForSave(formData.coding_config) : undefined,
                     }]}


### PR DESCRIPTION
closing #97 
Replaced the generic free-response textarea for short answer questions with a dedicated inline text input that renders directly in the question body
Added input restriction options for short answer questions — instructors can limit student responses to any text, numbers only, or letters only
Added a points field for short answer questions so instructors can specify how many points a correct match is worth
Updated QuestionCard to display the inline answer input and show valid answers 